### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/auto-build.yml
+++ b/.github/workflows/auto-build.yml
@@ -1,4 +1,6 @@
 name: auto-build
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/neurodesk/openrecon/security/code-scanning/2](https://github.com/neurodesk/openrecon/security/code-scanning/2)

To resolve the issue, add a `permissions` block at the root workflow level (above the `jobs:` key), making it explicit what permissions the workflow has. Given the visible jobs, the only apparent required privilege is the ability to read the repository contents. Thus, the best practice is to set:  

```yaml
permissions:
  contents: read
```

This block should be placed just below the `name:` field and above the `on:` key to apply to all jobs in the workflow. No other code changes are needed elsewhere. If any job in the future requires more privileges, those can be set on a job-specific basis.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
