### PR TITLE
Update openreconexample OpenRecon metadata to 1.0.0

### DIFF
--- a/recipes/openreconexample/OpenReconLabel.json
+++ b/recipes/openreconexample/OpenReconLabel.json
@@ -48,6 +48,13 @@
       ],
       "default": "openreconexample",
       "information": { "en": "Define the config to be executed by MRD server" }
+    },
+    {
+      "id": "sendoriginal",
+      "label": { "en": "Send original images" },
+      "type": "boolean",
+      "information": { "en": "Send a copy of original unmodified images back too" },
+      "default": true
     }
   ]
 }


### PR DESCRIPTION
## Summary

This PR updates OpenRecon metadata for **openreconexample** from the latest successful neurocontainers build.

## Changes

- Update `recipes/openreconexample/OpenReconLabel.json` from neurocontainers
- Set `recipes/openreconexample/params.sh` version to `1.0.0`

🤖 Generated by neurocontainers CI | Created by @stebo85