### PR TITLE
Update vesselboost OpenRecon metadata to 2.0.1

### DIFF
--- a/recipes/vesselboost/OpenReconLabel.json
+++ b/recipes/vesselboost/OpenReconLabel.json
@@ -50,25 +50,55 @@
       "information": { "en": "Define the config to be executed by MRD server" }
     },
     {
-      "id": "options",
-      "label": { "en": "options" },
+      "id": "vbmodules",
+      "label": { "en": "Vessel Boost Modules" },
       "type": "choice",
       "values": [
         {
-          "id": "none",
-          "name": { "en": "none" }
+          "id": "prediction",
+          "name": { "en": "prediction module" }
         },
         {
           "id": "tta",
-          "name": { "en": "tta" }
+          "name": { "en": "test-time adaptation" }
         },
         {
           "id": "booster",
           "name": { "en": "booster" }
         }
       ],
-      "default": "none",
-      "information": { "en": "Additional Vesselboost options" }
+      "default": "prediction",
+      "information": { "en": "Select a Vessel Boost module to run" }
+    },
+    {
+      "id": "vbepochs",
+      "label": { "en": "Epoch number" },
+      "type": "string",
+      "default": "200",
+      "information": { "en": "Enter an epoch number (integer) for tta/booster module" }
+    },
+    {
+      "id": "vbrate",
+      "label": { "en": "Learning rate" },
+      "type": "string",
+      "default": "0.001",
+      "information": { "en": "Enter a learning rate (float) for tta/booster module" }
+    },
+    {
+      "id": "vbprepmode",
+      "label": { "en": "Preprocessing mode" },
+      "type": "int",
+      "minimum": 1,
+      "maximum": 4,
+      "default": 1,
+      "information": { "en": "Preprocessing mode options. prep_mode=1 : bias field correction only | prep_mode=2 : denoising only | prep_mode=3 : bfc + denoising | prep_mode=4 : no preprocessing applied" }
+    },
+    {
+      "id": "vbbrainextraction",
+      "label": { "en": "Brain extraction flag" },
+      "type": "boolean",
+      "information": { "en": "Set true to enable brain extraction" },
+      "default": false
     }
   ]
 }

--- a/recipes/vesselboost/params.sh
+++ b/recipes/vesselboost/params.sh
@@ -2,7 +2,7 @@
 
 # build image here: https://github.com/NeuroDesk/neurocontainers and add mrd server instructions: https://www.neurodesk.org/docs/getting-started/neurocontainers/openrecon/
 # specify the repostiory and name of the docker image: https://hub.docker.com/orgs/vnmd/repositories
-export version=2.0.0
+export version=2.0.1
 export baseDockerImage=vnmd/vesselboost_${version}
 # this image is build based on 
 # https://github.com/neurodesk/neurocontainers/blob/main/recipes/vesselboost/build.yaml


### PR DESCRIPTION
## Summary

This PR updates OpenRecon metadata for **vesselboost** from the latest successful neurocontainers build.

## Changes

- Update `recipes/vesselboost/OpenReconLabel.json` from neurocontainers
- Set `recipes/vesselboost/params.sh` version to `2.0.1`

🤖 Generated by neurocontainers CI | Created by @stebo85