### PR TITLE
Update musclemap OpenRecon metadata to 1.2.3

### DIFF
--- a/recipes/musclemap/OpenReconLabel.json
+++ b/recipes/musclemap/OpenReconLabel.json
@@ -103,8 +103,8 @@
       "id": "chunksize",
       "label": { "en": "Chunk Size" },
       "type": "string",
-      "default": "100",
-      "information": { "en": "Chunk size between 5 and 200" }
+      "default": "auto",
+      "information": { "en": "Chunk size between 5 and 200 or 'auto'" }
     },
     {
       "id": "spatialoverlap",


### PR DESCRIPTION
## Summary

This PR updates OpenRecon metadata for **musclemap** from the latest successful neurocontainers build.

## Changes

- Update `recipes/musclemap/OpenReconLabel.json` from neurocontainers
- Set `recipes/musclemap/params.sh` version to `1.2.3`

🤖 Generated by neurocontainers CI | Created by @stebo85