### PR TITLE
Update vesselboost OpenRecon metadata to 2.0.3

### DIFF
--- a/recipes/vesselboost/params.sh
+++ b/recipes/vesselboost/params.sh
@@ -2,7 +2,7 @@
 
 # build image here: https://github.com/NeuroDesk/neurocontainers and add mrd server instructions: https://www.neurodesk.org/docs/getting-started/neurocontainers/openrecon/
 # specify the repostiory and name of the docker image: https://hub.docker.com/orgs/vnmd/repositories
-export version=2.0.1
+export version=2.0.3
 export baseDockerImage=vnmd/vesselboost_${version}
 # this image is build based on 
 # https://github.com/neurodesk/neurocontainers/blob/main/recipes/vesselboost/build.yaml


### PR DESCRIPTION
## Summary

This PR updates OpenRecon metadata for **vesselboost** from the latest successful neurocontainers build.

## Changes

- Update `recipes/vesselboost/OpenReconLabel.json` from neurocontainers
- Set `recipes/vesselboost/params.sh` version to `2.0.3`

🤖 Generated by neurocontainers CI | Created by @stebo85