### PR TITLE
Update musclemap OpenRecon metadata to 1.2.8

### DIFF
--- a/recipes/musclemap/params.sh
+++ b/recipes/musclemap/params.sh
@@ -2,7 +2,7 @@
 # build image here: https://github.com/NeuroDesk/neurocontainers and add mrd server instructions: https://www.neurodesk.org/docs/getting-started/neurocontainers/openrecon/
 # specify the repostiory and name of the docker image: https://hub.docker.com/orgs/vnmd/repositories
 export toolName=musclemap
-export version=1.2.4
+export version=1.2.8
 export baseDockerImage=vnmd/${toolName}_${version}
 # this image is build based on 
 # https://github.com/neurodesk/neurocontainers/blob/main/recipes/musclemap/build.yaml


### PR DESCRIPTION
## Summary

This PR updates OpenRecon metadata for **musclemap** from the latest successful neurocontainers build.

## Changes

- Update `recipes/musclemap/OpenReconLabel.json` from neurocontainers
- Set `recipes/musclemap/params.sh` version to `1.2.8`

🤖 Generated by neurocontainers CI | Created by @stebo85