### PR TITLE
Update vesselboost OpenRecon metadata to 2.0.10

### DIFF
--- a/recipes/vesselboost/OpenReconLabel.json
+++ b/recipes/vesselboost/OpenReconLabel.json
@@ -101,19 +101,24 @@
       "information": { "en": "Overlap percentage used only when Gaussian blending is enabled." }
     },
     {
-      "id": "vbprepmode",
-      "label": { "en": "Preprocessing mode" },
-      "type": "int",
-      "minimum": 1,
-      "maximum": 4,
-      "default": 1,
-      "information": { "en": "Preprocessing mode options. prep_mode=1 : bias field correction only | prep_mode=2 : denoising only | prep_mode=3 : bfc + denoising | prep_mode=4 : no preprocessing applied" }
+      "id": "vbbiasfieldcorrection",
+      "label": { "en": "N4 bias field correction" },
+      "type": "boolean",
+      "default": false,
+      "information": { "en": "Enable N4 bias field correction preprocessing." }
+    },
+    {
+      "id": "vbdenoising",
+      "label": { "en": "Denoising" },
+      "type": "boolean",
+      "default": false,
+      "information": { "en": "Enable non-local means denoising preprocessing." }
     },
     {
       "id": "vbbrainextraction",
-      "label": { "en": "Brain extraction flag" },
+      "label": { "en": "Brain masking" },
       "type": "boolean",
-      "information": { "en": "Set true to enable brain extraction" },
+      "information": { "en": "Enable SynthStrip brain extraction during preprocessing. Used only when N4 bias field correction or denoising is enabled." },
       "default": false
     }
   ]

--- a/recipes/vesselboost/params.sh
+++ b/recipes/vesselboost/params.sh
@@ -2,7 +2,7 @@
 
 # build image here: https://github.com/NeuroDesk/neurocontainers and add mrd server instructions: https://www.neurodesk.org/docs/getting-started/neurocontainers/openrecon/
 # specify the repostiory and name of the docker image: https://hub.docker.com/orgs/vnmd/repositories
-export version=2.0.9
+export version=2.0.10
 export baseDockerImage=vnmd/vesselboost_${version}
 # this image is build based on 
 # https://github.com/neurodesk/neurocontainers/blob/main/recipes/vesselboost/build.yaml


### PR DESCRIPTION
## Summary

This PR updates OpenRecon metadata for **vesselboost** from the latest successful neurocontainers build.

## Changes

- Update `recipes/vesselboost/OpenReconLabel.json` from neurocontainers
- Set `recipes/vesselboost/params.sh` version to `2.0.10`

🤖 Generated by neurocontainers CI | Created by @stebo85