### PR TITLE
Update vesselboost OpenRecon metadata to 2.0.11

### DIFF
--- a/recipes/vesselboost/OpenReconLabel.json
+++ b/recipes/vesselboost/OpenReconLabel.json
@@ -50,39 +50,11 @@
       "information": { "en": "Define the config to be executed by MRD server" }
     },
     {
-      "id": "vbmodules",
-      "label": { "en": "Vessel Boost Modules" },
-      "type": "choice",
-      "values": [
-        {
-          "id": "prediction",
-          "name": { "en": "prediction module" }
-        },
-        {
-          "id": "tta",
-          "name": { "en": "test-time adaptation" }
-        },
-        {
-          "id": "booster",
-          "name": { "en": "booster" }
-        }
-      ],
-      "default": "prediction",
-      "information": { "en": "Select a Vessel Boost module to run" }
-    },
-    {
-      "id": "vbepochs",
-      "label": { "en": "Epoch number" },
-      "type": "string",
-      "default": "200",
-      "information": { "en": "Enter an epoch number (integer) for tta/booster module" }
-    },
-    {
-      "id": "vbrate",
-      "label": { "en": "Learning rate" },
-      "type": "string",
-      "default": "0.001",
-      "information": { "en": "Enter a learning rate (float) for tta/booster module" }
+      "id": "sendoriginal",
+      "label": { "en": "Keep original images" },
+      "type": "boolean",
+      "default": true,
+      "information": { "en": "Return the original MRA images with the vesselboost_segmentation output." }
     },
     {
       "id": "vbuseblending",
@@ -101,20 +73,39 @@
       "information": { "en": "Overlap percentage used only when Gaussian blending is enabled." }
     },
     {
-      "id": "vbprepmode",
-      "label": { "en": "Preprocessing mode" },
-      "type": "int",
-      "minimum": 1,
-      "maximum": 4,
-      "default": 1,
-      "information": { "en": "Preprocessing mode options. prep_mode=1 : bias field correction only | prep_mode=2 : denoising only | prep_mode=3 : bfc + denoising | prep_mode=4 : no preprocessing applied" }
+      "id": "vbbiasfieldcorrection",
+      "label": { "en": "N4 bias field correction" },
+      "type": "boolean",
+      "default": true,
+      "information": { "en": "Enable N4 bias field correction preprocessing." }
+    },
+    {
+      "id": "vbdenoising",
+      "label": { "en": "Denoising" },
+      "type": "boolean",
+      "default": false,
+      "information": { "en": "Enable non-local means denoising preprocessing." }
     },
     {
       "id": "vbbrainextraction",
-      "label": { "en": "Brain extraction flag" },
+      "label": { "en": "Brain masking" },
       "type": "boolean",
-      "information": { "en": "Set true to enable brain extraction" },
-      "default": false
+      "information": { "en": "Enable SynthStrip brain extraction during preprocessing. Used only when N4 bias field correction or denoising is enabled." },
+      "default": true
+    },
+    {
+      "id": "vbreslicesagittal",
+      "label": { "en": "Reslice sagittal" },
+      "type": "boolean",
+      "default": false,
+      "information": { "en": "Emit an additional output series with the segmentation resliced in the sagittal plane." }
+    },
+    {
+      "id": "vbreslicecoronal",
+      "label": { "en": "Reslice coronal" },
+      "type": "boolean",
+      "default": false,
+      "information": { "en": "Emit an additional output series with the segmentation resliced in the coronal plane." }
     }
   ]
 }

--- a/recipes/vesselboost/README.md
+++ b/recipes/vesselboost/README.md
@@ -1,1 +1,67 @@
-Vesselboost will run a deep learning pipeline to segment an MRA TOF and output the segmentation.
+# VesselBoost OpenRecon
+
+VesselBoost runs a deep learning pipeline for vessel segmentation of high-resolution time-of-flight magnetic resonance angiography (TOF-MRA). It uses a UNet3D-based segmentation workflow designed to be sensitive to small vessels. The OpenRecon configuration exposes the prediction workflow and returns a derived `vesselboost_segmentation` image series.
+
+The normal VesselBoost software suite includes three command-line modules: prediction, test-time adaptation, and boost. In this OpenRecon application, the scanner GUI only makes the VesselBoost prediction pipeline available.
+
+## Input and Output
+
+Use this reconstruction pipeline on 3D TOF-MRA image data. 
+
+The output is a derived segmentation series named `vesselboost_segmentation`. By default, OpenRecon also returns the original MRA images before the segmentation output. Optional sagittal and coronal reformat series can be requested.
+
+## GUI Parameters
+
+| GUI label | Parameter id | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| config | `config` | choice | `vesselboost` | Selects the MRD server configuration. The available GUI option is `vesselboost`. |
+| Keep original images | `sendoriginal` | boolean | `true` | Return the original MRA images together with the `vesselboost_segmentation` output. Disable this to return only derived VesselBoost output series. |
+| Gaussian blending | `vbuseblending` | boolean | `false` | Experimental option that enables Gaussian blending across inference patches. This can smooth patch boundaries, but substantially increases runtime. |
+| Blend overlap % | `vboverlap` | integer | `50` | Patch overlap percentage used only when Gaussian blending is enabled. Valid GUI range: 0 to 99. |
+| N4 bias field correction | `vbbiasfieldcorrection` | boolean | `true` | Enable N4 bias field correction before VesselBoost inference. |
+| Denoising | `vbdenoising` | boolean | `false` | Enable non-local means denoising before VesselBoost inference. |
+| Brain masking | `vbbrainextraction` | boolean | `true` | Enable SynthStrip brain extraction during preprocessing. This is used only when N4 bias field correction or denoising is enabled. |
+| Reslice sagittal | `vbreslicesagittal` | boolean | `false` | Emit an additional sagittal reformat series of the segmentation. |
+| Reslice coronal | `vbreslicecoronal` | boolean | `false` | Emit an additional coronal reformat series of the segmentation. |
+
+## Preprocessing Combinations
+
+N4 bias field correction and denoising determine the VesselBoost preprocessing mode:
+
+| N4 bias field correction | Denoising | Effective preprocessing |
+| --- | --- | --- |
+| `true` | `false` | N4 bias field correction |
+| `false` | `true` | Non-local means denoising |
+| `true` | `true` | N4 bias field correction and denoising |
+| `false` | `false` | No preprocessing |
+
+Brain masking is applied during preprocessing. If both N4 bias field correction and denoising are disabled, the brain masking setting is ignored.
+
+## Runtime Notes
+
+Gaussian blending is marked experimental in the OpenRecon label. Use it only when smoother patch boundaries are worth the longer reconstruction time.
+
+The OpenRecon label declares GPU support and requests at least 1 GPU, 10048 MB GPU memory, 40096 MB system memory, and 32 CPU cores.
+
+## Citation
+
+Please cite VesselBoost if you use this reconstruction in research:
+
+```bibtex
+@article{xuVesselBoostPythonToolbox2024a,
+  title = {{{VesselBoost}}: {{A Python Toolbox}} for {{Small Blood Vessel Segmentation}} in {{Human Magnetic Resonance Angiography Data}}},
+  shorttitle = {{{VesselBoost}}},
+  author = {Xu, Marshall and Ribeiro, Fernanda L. and Barth, Markus and Bernier, Micha{\"e}l and Bollmann, Steffen and Chatterjee, Soumick and Cognolato, Francesco and Gulban, Omer F. and Itkyal, Vaibhavi and Liu, Siyu and Mattern, Hendrik and Polimeni, Jonathan R. and Shaw, Thomas B. and Speck, Oliver and Bollmann, Saskia},
+  year = {2024},
+  month = sep,
+  journal = {Aperture Neuro},
+  volume = {4},
+  publisher = {Organization for Human Brain Mapping},
+  issn = {2957-3963},
+  doi = {10.52294/001c.123217},
+  urldate = {2024-09-17},
+  copyright = {http://creativecommons.org/licenses/by/4.0},
+  langid = {english}
+}
+```
+

--- a/recipes/vesselboost/params.sh
+++ b/recipes/vesselboost/params.sh
@@ -2,7 +2,7 @@
 
 # build image here: https://github.com/NeuroDesk/neurocontainers and add mrd server instructions: https://www.neurodesk.org/docs/getting-started/neurocontainers/openrecon/
 # specify the repostiory and name of the docker image: https://hub.docker.com/orgs/vnmd/repositories
-export version=2.0.9
+export version=2.0.11
 export baseDockerImage=vnmd/vesselboost_${version}
 # this image is build based on 
 # https://github.com/neurodesk/neurocontainers/blob/main/recipes/vesselboost/build.yaml


### PR DESCRIPTION
## Summary

This PR updates OpenRecon metadata for **vesselboost** from the latest successful neurocontainers build.

## Changes

- Update `recipes/vesselboost/OpenReconLabel.json` from neurocontainers
- Set `recipes/vesselboost/params.sh` version to `2.0.11`
- Copy `recipes/vesselboost/OpenRecon_README.md` from neurocontainers to `recipes/vesselboost/README.md` for OpenRecon PDF generation

🤖 Generated by neurocontainers CI | Created by @stebo85