### PR TITLE
Update musclemap OpenRecon metadata to 1.3.6

### DIFF
--- a/recipes/musclemap/OpenReconLabel.json
+++ b/recipes/musclemap/OpenReconLabel.json
@@ -71,6 +71,34 @@
       "default": false
     },
     {
+      "id": "computemetrics",
+      "label": { "en": "Compute segmentation metrics" },
+      "type": "boolean",
+      "information": { "en": "Run MuscleMap average metrics on the generated segmentation and source image." },
+      "default": false
+    },
+    {
+      "id": "metricsburnseries",
+      "label": { "en": "Send metrics report series" },
+      "type": "boolean",
+      "information": { "en": "Return a separate burned-in image series containing the metrics table." },
+      "default": false
+    },
+    {
+      "id": "metricsincomments",
+      "label": { "en": "Metrics in image comments" },
+      "type": "boolean",
+      "information": { "en": "Add a compact MuscleMap metrics summary to ImageComments." },
+      "default": false
+    },
+    {
+      "id": "metricsinminihead",
+      "label": { "en": "Metrics in IceMiniHead" },
+      "type": "boolean",
+      "information": { "en": "Add a compact MuscleMapMetrics entry to the Siemens IceMiniHead when present." },
+      "default": false
+    },
+    {
       "id": "bodyregion",
       "label": { "en": "Body Region" },
       "type": "choice",
@@ -98,6 +126,13 @@
       ],
       "default": "wholebody",
       "information": { "en": "Select the body region for segmentation" }
+    },
+    {
+      "id": "metricsregion",
+      "label": { "en": "Metrics Region" },
+      "type": "string",
+      "default": "",
+      "information": { "en": "Optional region passed to MuscleMap metrics; leave empty to use Body Region." }
     },
     {
       "id": "chunksize",

--- a/recipes/musclemap/params.sh
+++ b/recipes/musclemap/params.sh
@@ -2,7 +2,7 @@
 # build image here: https://github.com/NeuroDesk/neurocontainers and add mrd server instructions: https://www.neurodesk.org/docs/getting-started/neurocontainers/openrecon/
 # specify the repostiory and name of the docker image: https://hub.docker.com/orgs/vnmd/repositories
 export toolName=musclemap
-export version=1.3.4
+export version=1.3.6
 export baseDockerImage=vnmd/${toolName}_${version}
 # this image is build based on 
 # https://github.com/neurodesk/neurocontainers/blob/main/recipes/musclemap/build.yaml


### PR DESCRIPTION
## Summary

This PR updates OpenRecon metadata for **musclemap** from the latest successful neurocontainers build.

## Changes

- Update `recipes/musclemap/OpenReconLabel.json` from neurocontainers
- Set `recipes/musclemap/params.sh` version to `1.3.6`
- Copy `recipes/musclemap/OpenReconREADME.md` from neurocontainers to `recipes/musclemap/README.md` for OpenRecon PDF generation

🤖 Generated by neurocontainers CI | Created by @stebo85