### PR TITLE
Update musclemap OpenRecon metadata to 1.3.10

### DIFF
--- a/recipes/musclemap/OpenReconLabel.json
+++ b/recipes/musclemap/OpenReconLabel.json
@@ -75,28 +75,28 @@
       "label": { "en": "Compute segmentation metrics" },
       "type": "boolean",
       "information": { "en": "Run MuscleMap average metrics on the generated segmentation and source image." },
-      "default": false
+      "default": true
     },
     {
       "id": "metricsburnseries",
       "label": { "en": "Send metrics report series" },
       "type": "boolean",
       "information": { "en": "Return a separate burned-in image series containing the metrics table." },
-      "default": false
+      "default": true
     },
     {
       "id": "metricsincomments",
       "label": { "en": "Metrics in image comments" },
       "type": "boolean",
       "information": { "en": "Add a compact MuscleMap metrics summary to ImageComments." },
-      "default": false
+      "default": true
     },
     {
       "id": "metricsinminihead",
       "label": { "en": "Metrics in IceMiniHead" },
       "type": "boolean",
       "information": { "en": "Add a compact MuscleMapMetrics entry to the Siemens IceMiniHead when present." },
-      "default": false
+      "default": true
     },
     {
       "id": "bodyregion",

--- a/recipes/musclemap/params.sh
+++ b/recipes/musclemap/params.sh
@@ -2,7 +2,7 @@
 # build image here: https://github.com/NeuroDesk/neurocontainers and add mrd server instructions: https://www.neurodesk.org/docs/getting-started/neurocontainers/openrecon/
 # specify the repostiory and name of the docker image: https://hub.docker.com/orgs/vnmd/repositories
 export toolName=musclemap
-export version=1.3.6
+export version=1.3.10
 export baseDockerImage=vnmd/${toolName}_${version}
 # this image is build based on 
 # https://github.com/neurodesk/neurocontainers/blob/main/recipes/musclemap/build.yaml


### PR DESCRIPTION
## Summary

This PR updates OpenRecon metadata for **musclemap** from the latest successful neurocontainers build.

## Changes

- Update `recipes/musclemap/OpenReconLabel.json` from neurocontainers
- Set `recipes/musclemap/params.sh` version to `1.3.10`
- Copy `recipes/musclemap/OpenReconREADME.md` from neurocontainers to `recipes/musclemap/README.md` for OpenRecon PDF generation

🤖 Generated by neurocontainers CI | Created by @stebo85