### PR TITLE
Update musclemap OpenRecon metadata to 1.3.12

### DIFF
--- a/recipes/musclemap/OpenReconLabel.json
+++ b/recipes/musclemap/OpenReconLabel.json
@@ -72,14 +72,14 @@
     },
     {
       "id": "computemetrics",
-      "label": { "en": "Compute segmentation metrics" },
+      "label": { "en": "Compute metrics" },
       "type": "boolean",
       "information": { "en": "Run MuscleMap average metrics on the generated segmentation and source image." },
       "default": true
     },
     {
       "id": "metricsburnseries",
-      "label": { "en": "Send metrics report series" },
+      "label": { "en": "Metrics in DICOM" },
       "type": "boolean",
       "information": { "en": "Return a separate burned-in image series containing the metrics table." },
       "default": true
@@ -130,7 +130,29 @@
     {
       "id": "metricsregion",
       "label": { "en": "Metrics Region" },
-      "type": "string",
+      "type": "choice",
+      "values": [
+        {
+          "id": "wholebody",
+          "name": { "en": "wholebody" }
+        },
+        {
+          "id": "abdomen",
+          "name": { "en": "abdomen" }
+        },
+        {
+          "id": "pelvis",
+          "name": { "en": "pelvis" }
+        },
+        {
+          "id": "thigh",
+          "name": { "en": "thigh" }
+        },
+        {
+          "id": "leg",
+          "name": { "en": "leg" }
+        }
+      ],
       "default": "",
       "information": { "en": "Optional region passed to MuscleMap metrics; leave empty to use Body Region." }
     },

--- a/recipes/musclemap/params.sh
+++ b/recipes/musclemap/params.sh
@@ -2,7 +2,7 @@
 # build image here: https://github.com/NeuroDesk/neurocontainers and add mrd server instructions: https://www.neurodesk.org/docs/getting-started/neurocontainers/openrecon/
 # specify the repostiory and name of the docker image: https://hub.docker.com/orgs/vnmd/repositories
 export toolName=musclemap
-export version=1.3.10
+export version=1.3.12
 export baseDockerImage=vnmd/${toolName}_${version}
 # this image is build based on 
 # https://github.com/neurodesk/neurocontainers/blob/main/recipes/musclemap/build.yaml


### PR DESCRIPTION
## Summary

This PR updates OpenRecon metadata for **musclemap** from the latest successful neurocontainers build.

## Changes

- Update `recipes/musclemap/OpenReconLabel.json` from neurocontainers
- Set `recipes/musclemap/params.sh` version to `1.3.12`
- Copy `recipes/musclemap/OpenReconREADME.md` from neurocontainers to `recipes/musclemap/README.md` for OpenRecon PDF generation

🤖 Generated by neurocontainers CI | Created by @stebo85