### PR TITLE
Update musclemap OpenRecon metadata to 1.3.18

### DIFF
--- a/recipes/musclemap/OpenReconLabel.json
+++ b/recipes/musclemap/OpenReconLabel.json
@@ -75,28 +75,28 @@
       "label": { "en": "Compute metrics" },
       "type": "boolean",
       "information": { "en": "Run MuscleMap average metrics on the generated segmentation and source image." },
-      "default": false
+      "default": true
     },
     {
       "id": "metricsburnseries",
       "label": { "en": "Metrics in DICOM" },
       "type": "boolean",
       "information": { "en": "Return a separate burned-in image series containing the metrics table." },
-      "default": false
+      "default": true
     },
     {
       "id": "metricsincomments",
       "label": { "en": "Metrics in image comments" },
       "type": "boolean",
       "information": { "en": "Add a compact MuscleMap metrics summary to ImageComments." },
-      "default": false
+      "default": true
     },
     {
       "id": "metricsinminihead",
       "label": { "en": "Metrics in IceMiniHead" },
       "type": "boolean",
       "information": { "en": "Add a compact MuscleMapMetrics entry to the Siemens IceMiniHead when present." },
-      "default": false
+      "default": true
     },
     {
       "id": "bodyregion",


### PR DESCRIPTION
## Summary

This PR updates OpenRecon metadata for **musclemap** from the latest successful neurocontainers build.

## Changes

- Update `recipes/musclemap/OpenReconLabel.json` from neurocontainers
- Set `recipes/musclemap/params.sh` version to `1.3.18`
- Copy `recipes/musclemap/OpenReconREADME.md` from neurocontainers to `recipes/musclemap/README.md` for OpenRecon PDF generation

🤖 Generated by neurocontainers CI | Created by @stebo85