### PR TITLE
Update metabody OpenRecon metadata to 1.0.2

### DIFF
--- a/recipes/metabody/OpenReconLabel.json
+++ b/recipes/metabody/OpenReconLabel.json
@@ -31,7 +31,7 @@
     "can_use_gpu": false,
     "min_count_required_gpus": 0,
     "min_required_gpu_memory": 2048,
-    "min_required_memory": 4096,
+    "min_required_memory": 8192,
     "min_count_required_cpu_cores": 1,
     "content_qualification_type": "RESEARCH"
   },

--- a/recipes/metabody/params.sh
+++ b/recipes/metabody/params.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # build image here: https://github.com/NeuroDesk/neurocontainers and add mrd server instructions: https://www.neurodesk.org/docs/getting-started/neurocontainers/openrecon/
 export toolName=metabody
-export version=1.0.1
+export version=1.0.2
 export baseDockerImage=vnmd/${toolName}_${version}
 # this image is build based on 
 # https://github.com/neurodesk/neurocontainers/blob/main/recipes/metabody/build.yaml


### PR DESCRIPTION
## Summary

This PR updates OpenRecon metadata for **metabody** from the latest successful neurocontainers build.

## Changes

- Update `recipes/metabody/OpenReconLabel.json` from neurocontainers
- Set `recipes/metabody/params.sh` version to `1.0.2`



🤖 Generated by neurocontainers CI | Created by @stebo85