### PR TITLE
Update musclemap OpenRecon metadata to 1.3.33

### DIFF
--- a/recipes/musclemap/OpenReconLabel.json
+++ b/recipes/musclemap/OpenReconLabel.json
@@ -53,7 +53,7 @@
       "id": "sendoriginal",
       "label": { "en": "Send original images" },
       "type": "boolean",
-      "information": { "en": "Send a copy of original unmodified images back too" },
+      "information": { "en": "Return source-native 2D original images before the MuscleMap-derived outputs, with fresh scanner storage identity." },
       "default": true
     },
     {

--- a/recipes/musclemap/README.md
+++ b/recipes/musclemap/README.md
@@ -24,11 +24,33 @@ https://doi.org/10.3390/jimaging10110262
 
 | ID | Label | Type | Default | Description |
 | :--- | :--- | :--- | :--- | :--- |
-| `sendoriginal` | Send original images | boolean | `true` | Send a copy of original unmodified images back too |
+| `sendoriginal` | Send original images | boolean | `true` | Return source-native 2D original images before the MuscleMap-derived outputs, with fresh scanner storage identity |
 | `labeltransform` | Scale labels to lower integer range for DICOM 12BIT | boolean | `true` | Applying label transformation: 3 * (label_in // 10) + (label_in % 10) |
 | `bodyregion` | Body Region | choice | `wholebody, abdomen, pelvis, thigh, leg` | Select the body region for segmentation |
 | `chunksize` | Chunk Size | string | `100` | Chunk size between 5 and 200 - change for memory optimization on GPU |
 | `spatialoverlap` | Spatial Overlap | int | `50` | Spatial overlap percentage |
+
+# Scanner output handling
+
+MuscleMap buffers the incoming image stream before returning anything to the
+scanner. When `sendoriginal` is enabled, all received source images are returned
+first as source-native 2D passthrough images: source protocol, sequence,
+image-type, slice, and per-image numbering fields are preserved while
+series/storage UIDs are refreshed. Scanner partition counters such as
+`Actual3DImagePartNumber` and `AnatomicalPartitionNo` are forced to the returned
+single-partition stream (`0`) instead of copying source partition values. If
+`sendoriginal` is disabled, non-processed input images are still returned with
+the same source-native passthrough handling.
+
+MuscleMap segmentation images are sent after the source passthrough stream as
+source-geometry 2D masks with fresh series identity, fresh SOP identity,
+`SequenceDescriptionAdditional = openrecon`, `Keep_image_geometry = 1`,
+`DataRole = Segmentation`, and `SegmentSourceGeometry = 1`. This matches the
+`openreconi2iexample` 2D + detach + after-originals path when
+`segmentpostprocessingstamp` is disabled. Optional metrics report output follows
+the `openreconi2iexample` metrics path: one standalone explicit-volume derived
+image, preferring `image_series_index = 120` when available, with
+`DataRole = Segmentation`, `Keep_image_geometry = 0`, and no `IceMiniHead`.
 
 # Labels
 

--- a/recipes/musclemap/params.sh
+++ b/recipes/musclemap/params.sh
@@ -2,7 +2,7 @@
 # build image here: https://github.com/NeuroDesk/neurocontainers and add mrd server instructions: https://www.neurodesk.org/docs/getting-started/neurocontainers/openrecon/
 # specify the repostiory and name of the docker image: https://hub.docker.com/orgs/vnmd/repositories
 export toolName=musclemap
-export version=1.3.32
+export version=1.3.33
 export baseDockerImage=vnmd/${toolName}_${version}
 # this image is build based on 
 # https://github.com/neurodesk/neurocontainers/blob/main/recipes/musclemap/build.yaml


### PR DESCRIPTION
## Summary

This PR updates OpenRecon metadata for **musclemap** from the latest successful neurocontainers build.

## Changes

- Update `recipes/musclemap/OpenReconLabel.json` from neurocontainers
- Set `recipes/musclemap/params.sh` version to `1.3.33`

- Copy `recipes/musclemap/OpenReconREADME.md` from neurocontainers to `recipes/musclemap/README.md` for OpenRecon PDF generation

🤖 Generated by neurocontainers CI | Created by @stebo85