### PR TITLE
Update vesselboost OpenRecon metadata to 2.0.56

### DIFF
--- a/recipes/vesselboost/OpenReconLabel.json
+++ b/recipes/vesselboost/OpenReconLabel.json
@@ -54,7 +54,7 @@
       "label": { "en": "Keep original images" },
       "type": "boolean",
       "default": true,
-      "information": { "en": "Return restamped original MRA images first, before the SegmentPostProcessing-stamped VesselBoost segmentation." }
+      "information": { "en": "Return restamped original MRA images first, before the source-image-header 2D VesselBoost segmentation." }
     },
     {
       "id": "vbdebugthresholdsegment",
@@ -113,6 +113,13 @@
       "type": "boolean",
       "default": false,
       "information": { "en": "Emit an additional output series with the segmentation resliced in the coronal plane." }
+    },
+    {
+      "id": "vbsegmentationmips",
+      "label": { "en": "Segmentation MIPs" },
+      "type": "boolean",
+      "default": false,
+      "information": { "en": "Also produce scanner inline radial MIPs of the segmentation, in addition to the original-scan MIPs. When off, the segmentation is sent as a post-processing child and excluded from the inline MIP." }
     }
   ]
 }

--- a/recipes/vesselboost/README.md
+++ b/recipes/vesselboost/README.md
@@ -8,14 +8,15 @@ The normal VesselBoost software suite includes three command-line modules: predi
 
 Use this reconstruction pipeline on 3D TOF-MRA image data.
 
-The main derived output is named `<source>_vesselboost`, where `<source>` is the incoming source `SeriesDescription`. If the source series has no description, the fallback name is `vesselboost`. By default, OpenRecon also returns the original MRA images before the derived output. Optional sagittal and coronal reformat series are named `<source>_vesselboost_sagittal` and `<source>_vesselboost_coronal`.
+The main derived output is named `<source>_vesselboost`, where `<source>` is the incoming source `SeriesDescription` or, when that is absent, the incoming `SequenceDescription`. If neither source name is available, the fallback name is `vesselboost`. Returned scanner series use `OR` as the short OpenRecon suffix. By default, OpenRecon returns restamped original MRA images first as `<source>_original`, then sends one source-image-header 2D VesselBoost segmentation image per source image. Optional sagittal and coronal reformat series are named `<source>_vesselboost_sagittal` and `<source>_vesselboost_coronal`.
 
 ## GUI Parameters
 
 | GUI label | Parameter id | Type | Default | Description |
 | --- | --- | --- | --- | --- |
 | config | `config` | choice | `vesselboost` | Selects the MRD server configuration. The available GUI option is `vesselboost`. |
-| Keep original images | `sendoriginal` | boolean | `true` | Return the original MRA images together with the `vesselboost_segmentation` output. Disable this to return only derived VesselBoost output series. |
+| Keep original images | `sendoriginal` | boolean | `true` | Return restamped original MRA images first, before the `vesselboost` output. Disable this to return only derived VesselBoost output series. |
+| Debug threshold segmentation | `vbdebugthresholdsegment` | boolean | `false` | Skip VesselBoost inference and use the simple threshold segmentation from `openreconi2iexample` to exercise the send path quickly. |
 | Gaussian blending | `vbuseblending` | boolean | `false` | Experimental option that enables Gaussian blending across inference patches. This can smooth patch boundaries, but substantially increases runtime. |
 | Blend overlap % | `vboverlap` | integer | `50` | Patch overlap percentage used only when Gaussian blending is enabled. Valid GUI range: 0 to 99. |
 | N4 bias field correction | `vbbiasfieldcorrection` | boolean | `true` | Enable N4 bias field correction before VesselBoost inference. |
@@ -41,7 +42,13 @@ Brain masking is applied during preprocessing. If both N4 bias field correction 
 
 Gaussian blending is marked experimental in the OpenRecon label. Use it only when smoother patch boundaries are worth the longer reconstruction time.
 
+`vbdebugthresholdsegment` is a diagnostic flag. When enabled, the wrapper still receives and sorts the source TOF images, but skips the VesselBoost model command and creates a simple threshold plus largest-component mask using the same logic as `openreconi2iexample`.
+
 The OpenRecon label declares GPU support and requests at least 1 GPU, 10048 MB GPU memory, 40096 MB system memory, and 32 CPU cores.
+
+Returned images are always emitted as new scanner-visible series. Restamped originals are sent first with `Keep_image_geometry = 1` and a patched source `IceMiniHead`, so scanner-side processing and scanner-created MIPs stay attached to the original MRA geometry. The VesselBoost segmentation follows as a separate source-image-header 2D stream with `Keep_image_geometry = 1`, `DataRole = Image`, `SegmentSourceGeometry = 1`, `SegmentSourceImageHeader = 1`, `SegmentOutputGeometry = 2d`, and the source `ImageType`, `DicomImageType`, and `ImageTypeValue4` identity. The segment stream strips `ImageTypeValue3` from MRD metadata and `IceMiniHead` so Siemens MIP functors that select `ImageTypeValue3 = M` stay attached to the original stream.
+
+This mirrors the `openreconi2iexample` `2d_source_image_header` path with segment geometry fixed to `2d`, no detached 3D data, and segment send order after originals. Reformatted sagittal and coronal outputs remain explicit packed 3D MRD volumes without source-image-header stamping.
 
 ## Citation
 

--- a/recipes/vesselboost/params.sh
+++ b/recipes/vesselboost/params.sh
@@ -2,7 +2,7 @@
 
 # build image here: https://github.com/NeuroDesk/neurocontainers and add mrd server instructions: https://www.neurodesk.org/docs/getting-started/neurocontainers/openrecon/
 # specify the repostiory and name of the docker image: https://hub.docker.com/orgs/vnmd/repositories
-export version=2.0.55
+export version=2.0.56
 export baseDockerImage=vnmd/vesselboost_${version}
 # this image is build based on 
 # https://github.com/neurodesk/neurocontainers/blob/main/recipes/vesselboost/build.yaml


### PR DESCRIPTION
## Summary

This PR updates OpenRecon metadata for **vesselboost** from the latest successful neurocontainers build.

## Changes

- Update `recipes/vesselboost/OpenReconLabel.json` from neurocontainers
- Set `recipes/vesselboost/params.sh` version to `2.0.56`

- Copy `recipes/vesselboost/OpenReconREADME.md` from neurocontainers to `recipes/vesselboost/README.md` for OpenRecon PDF generation

🤖 Generated by neurocontainers CI | Created by @stebo85