### PR TITLE
Update musclemap OpenRecon metadata to 1.3.34

### DIFF
--- a/recipes/musclemap/OpenReconLabel.json
+++ b/recipes/musclemap/OpenReconLabel.json
@@ -57,6 +57,34 @@
       "default": true
     },
     {
+      "id": "segmentwater",
+      "label": { "en": "Segment Water" },
+      "type": "boolean",
+      "information": { "en": "Run MuscleMap segmentation on the Dixon water image." },
+      "default": false
+    },
+    {
+      "id": "segmentinphase",
+      "label": { "en": "Segment Inphase" },
+      "type": "boolean",
+      "information": { "en": "Run MuscleMap segmentation on the Dixon in-phase image." },
+      "default": false
+    },
+    {
+      "id": "segmentopposedphase",
+      "label": { "en": "Segment Opposed Phase" },
+      "type": "boolean",
+      "information": { "en": "Run MuscleMap segmentation on the Dixon opposed-phase image." },
+      "default": true
+    },
+    {
+      "id": "segmentfat",
+      "label": { "en": "Segment Fat" },
+      "type": "boolean",
+      "information": { "en": "Run MuscleMap segmentation on the Dixon fat image." },
+      "default": false
+    },
+    {
       "id": "labeltransform",
       "label": { "en": "Label Transform" },
       "type": "boolean",


### PR DESCRIPTION
## Summary

This PR updates OpenRecon metadata for **musclemap** from the latest successful neurocontainers build.

## Changes

- Update `recipes/musclemap/OpenReconLabel.json` from neurocontainers
- Set `recipes/musclemap/params.sh` version to `1.3.34`

- Copy `recipes/musclemap/OpenReconREADME.md` from neurocontainers to `recipes/musclemap/README.md` for OpenRecon PDF generation

🤖 Generated by neurocontainers CI | Created by @stebo85