### PR TITLE
Update vesselboost OpenRecon metadata to 2.0.61

### DIFF
--- a/recipes/vesselboost/OpenReconLabel.json
+++ b/recipes/vesselboost/OpenReconLabel.json
@@ -119,7 +119,7 @@
       "label": { "en": "Segmentation MIPs" },
       "type": "boolean",
       "default": false,
-      "information": { "en": "Also produce scanner inline radial MIPs of the segmentation, in addition to the original-scan MIPs. When off, the segmentation is sent as a post-processing child and excluded from the inline MIP." }
+      "information": { "en": "Use the openreconi2iexample 2D segmentation-header delivery mode: the segmentation is sent without source-image-header metadata and becomes the scanner post-processing target for separate segmentation MIPs." }
     }
   ]
 }

--- a/recipes/vesselboost/README.md
+++ b/recipes/vesselboost/README.md
@@ -8,10 +8,7 @@ The normal VesselBoost software suite includes three command-line modules: predi
 
 Use this reconstruction pipeline on 3D TOF-MRA image data.
 
-The main derived output is named `<source>_vesselboost`, where `<source>` is the incoming source `SeriesDescription` or, when that is absent, the incoming `SequenceDescription`.
-If neither source name is available, the fallback name is `vesselboost`. Returned scanner series use `OR` as the short OpenRecon suffix.
-By default, OpenRecon returns restamped original MRA images first as `<source>_original`, then sends one source-image-header 2D VesselBoost segmentation image per source image.
-Optional sagittal and coronal reformat series are named `<source>_vesselboost_sagittal` and `<source>_vesselboost_coronal`.
+The main derived output is named `<source>_vesselboost`, where `<source>` is the incoming source `SeriesDescription` or, when that is absent, the incoming `SequenceDescription`. If neither source name is available, the fallback name is `vesselboost`. Returned scanner series use `OR` as the short OpenRecon suffix. By default, OpenRecon returns restamped original MRA images first as `<source>_original`, then sends one source-image-header 2D VesselBoost segmentation image per source image. Optional sagittal and coronal reformat series are named `<source>_vesselboost_sagittal` and `<source>_vesselboost_coronal`.
 
 ## GUI Parameters
 
@@ -27,6 +24,7 @@ Optional sagittal and coronal reformat series are named `<source>_vesselboost_sa
 | Brain masking | `vbbrainextraction` | boolean | `true` | Enable SynthStrip brain extraction during preprocessing. This is used only when N4 bias field correction or denoising is enabled. |
 | Reslice sagittal | `vbreslicesagittal` | boolean | `false` | Emit an additional sagittal reformat series of the segmentation. |
 | Reslice coronal | `vbreslicecoronal` | boolean | `false` | Emit an additional coronal reformat series of the segmentation. |
+| Segmentation MIPs | `vbsegmentationmips` | boolean | `false` | Use the `openreconi2iexample` 2D segmentation-header delivery mode so scanner post-processing targets the segmentation stream. |
 
 ## Preprocessing Combinations
 
@@ -49,12 +47,9 @@ Gaussian blending is marked experimental in the OpenRecon label. Use it only whe
 
 The OpenRecon label declares GPU support and requests at least 1 GPU, 10048 MB GPU memory, 40096 MB system memory, and 32 CPU cores.
 
-Returned images are always emitted as new scanner-visible series.
-Restamped originals are sent first with `Keep_image_geometry = 1` and a patched source `IceMiniHead`, so scanner-side processing and scanner-created MIPs stay attached to the original MRA geometry.
-The VesselBoost segmentation follows as a separate source-image-header 2D stream with `Keep_image_geometry = 1`, `DataRole = Image`, `SegmentSourceGeometry = 1`, `SegmentSourceImageHeader = 1`, `SegmentOutputGeometry = 2d`, and the source `ImageType`, `DicomImageType`, and `ImageTypeValue4` identity.
-The segment stream strips `ImageTypeValue3` from MRD metadata and `IceMiniHead` so Siemens MIP functors that select `ImageTypeValue3 = M` stay attached to the original stream.
+Returned images are always emitted as new scanner-visible series. Restamped originals are sent first with `Keep_image_geometry = 1` and a patched source `IceMiniHead`, so scanner-side processing and scanner-created MIPs stay attached to the original MRA geometry. By default, the VesselBoost segmentation follows as a separate source-image-header 2D stream with `Keep_image_geometry = 1`, `DataRole = Image`, `SegmentSourceGeometry = 1`, `SegmentSourceImageHeader = 1`, `SegmentOutputGeometry = 2d`, the scanner post-processing child role, and the source `ImageType`, `DicomImageType`, and `ImageTypeValue4` identity. In normal mode, the segment stream strips `ImageTypeValue3` from MRD metadata and `IceMiniHead` so Siemens MIP functors that select `ImageTypeValue3 = M` stay attached to the original stream.
 
-This mirrors the `openreconi2iexample` `2d_source_image_header` path with segment geometry fixed to `2d`, no detached 3D data, and segment send order after originals. Reformatted sagittal and coronal outputs remain explicit packed 3D MRD volumes without source-image-header stamping.
+When `vbsegmentationmips` is enabled, VesselBoost instead mirrors the `openreconi2iexample` `2d_segment_header` path: the segmentation is sent as a 2D source-geometry segmentation-header stream with `DataRole = Segmentation`, `SegmentSourceGeometry = 1`, `SegmentOutputGeometry = 2d`, no `SegmentSourceImageHeader`, scanner post-processing child-role metadata matching the segmentation `image_series_index`, and no `ImageTypeValue3`. This lets scanner-created segmentation MIPs appear as their own post-processed segmentation series instead of being folded into original MIP side products. Reformatted sagittal and coronal outputs remain explicit packed 3D MRD volumes without source-image-header stamping.
 
 ## Citation
 

--- a/recipes/vesselboost/params.sh
+++ b/recipes/vesselboost/params.sh
@@ -2,7 +2,7 @@
 
 # build image here: https://github.com/NeuroDesk/neurocontainers and add mrd server instructions: https://www.neurodesk.org/docs/getting-started/neurocontainers/openrecon/
 # specify the repostiory and name of the docker image: https://hub.docker.com/orgs/vnmd/repositories
-export version=2.0.60
+export version=2.0.61
 export baseDockerImage=vnmd/vesselboost_${version}
 # this image is build based on 
 # https://github.com/neurodesk/neurocontainers/blob/main/recipes/vesselboost/build.yaml


### PR DESCRIPTION
## Summary

This PR updates OpenRecon metadata for **vesselboost** from the latest successful neurocontainers build.

## Changes

- Update `recipes/vesselboost/OpenReconLabel.json` from neurocontainers
- Set `recipes/vesselboost/params.sh` version to `2.0.61`

- Copy `recipes/vesselboost/OpenReconREADME.md` from neurocontainers to `recipes/vesselboost/README.md` for OpenRecon PDF generation

🤖 Generated by neurocontainers CI | Created by @stebo85