### PR TITLE
Update musclemap OpenRecon metadata to 1.3.37

### DIFF
--- a/recipes/musclemap/OpenReconLabel.json
+++ b/recipes/musclemap/OpenReconLabel.json
@@ -57,6 +57,34 @@
       "default": true
     },
     {
+      "id": "segmentwater",
+      "label": { "en": "Segment Water" },
+      "type": "boolean",
+      "information": { "en": "Run MuscleMap segmentation on the Dixon water image." },
+      "default": false
+    },
+    {
+      "id": "segmentinphase",
+      "label": { "en": "Segment Inphase" },
+      "type": "boolean",
+      "information": { "en": "Run MuscleMap segmentation on the Dixon in-phase image." },
+      "default": false
+    },
+    {
+      "id": "segmentopposedphase",
+      "label": { "en": "Segment Opposed Phase" },
+      "type": "boolean",
+      "information": { "en": "Run MuscleMap segmentation on the Dixon opposed-phase image." },
+      "default": true
+    },
+    {
+      "id": "segmentfat",
+      "label": { "en": "Segment Fat" },
+      "type": "boolean",
+      "information": { "en": "Run MuscleMap segmentation on the Dixon fat image." },
+      "default": false
+    },
+    {
       "id": "labeltransform",
       "label": { "en": "Label Transform" },
       "type": "boolean",
@@ -71,32 +99,37 @@
       "default": false
     },
     {
-      "id": "computemetrics",
-      "label": { "en": "Compute metrics" },
-      "type": "boolean",
-      "information": { "en": "Run MuscleMap average metrics on the generated segmentation and source image." },
-      "default": true
-    },
-    {
-      "id": "metricsburnseries",
-      "label": { "en": "Metrics in DICOM" },
-      "type": "boolean",
-      "information": { "en": "Return a separate burned-in image series containing the metrics table." },
-      "default": true
-    },
-    {
-      "id": "metricsincomments",
-      "label": { "en": "Metrics in image comments" },
-      "type": "boolean",
-      "information": { "en": "Add a compact MuscleMap metrics summary to ImageComments." },
-      "default": true
-    },
-    {
-      "id": "metricsinminihead",
-      "label": { "en": "Metrics in IceMiniHead" },
-      "type": "boolean",
-      "information": { "en": "Add a compact MuscleMapMetrics entry to the Siemens IceMiniHead when present." },
-      "default": true
+      "id": "metricsoutput",
+      "label": { "en": "Metrics output" },
+      "type": "choice",
+      "values": [
+        {
+          "id": "all",
+          "name": { "en": "DICOM + comments + IceMiniHead" }
+        },
+        {
+          "id": "dicom",
+          "name": { "en": "DICOM only" }
+        },
+        {
+          "id": "comments",
+          "name": { "en": "Image comments only" }
+        },
+        {
+          "id": "minihead",
+          "name": { "en": "IceMiniHead only" }
+        },
+        {
+          "id": "metadata",
+          "name": { "en": "Comments + IceMiniHead" }
+        },
+        {
+          "id": "none",
+          "name": { "en": "None" }
+        }
+      ],
+      "default": "all",
+      "information": { "en": "Select where MuscleMap average metrics are returned." }
     },
     {
       "id": "bodyregion",

--- a/recipes/musclemap/README.md
+++ b/recipes/musclemap/README.md
@@ -2,7 +2,7 @@
 
 This OpenRecon tool is based on the MuscleMap Toolbox (https://github.com/MuscleMap/MuscleMap) - A free and open-source software toolbox for whole-body muscle segmentation and analysis.
 
-It runs on Water images of a Dixon sequence and generates muscle segmentations.
+It runs on the selected image type from a Dixon sequence and generates muscle segmentations. Opposed Phase is selected by default.
 
 We are currently developing the standardized acquisition protocol for whole-body quantitative MRI of muscle. You can access the Google doc here: https://docs.google.com/document/d/1q7AAnPEr7Rj5gb9d_mLrRnAiav1f32J-RPswvOPk5xE/edit?usp=sharing. To collaborate on the standardized acquisition protocol, please contact us: neuromuscularinsightlab@stanford.edu.
 
@@ -25,7 +25,12 @@ https://doi.org/10.3390/jimaging10110262
 | ID | Label | Type | Default | Description |
 | :--- | :--- | :--- | :--- | :--- |
 | `sendoriginal` | Send original images | boolean | `true` | Return source-native 2D original images before the MuscleMap-derived outputs, with fresh scanner storage identity |
+| `segmentwater` | Segment Water | boolean | `false` | Run MuscleMap segmentation on the Dixon water image |
+| `segmentinphase` | Segment Inphase | boolean | `false` | Run MuscleMap segmentation on the Dixon in-phase image |
+| `segmentopposedphase` | Segment Opposed Phase | boolean | `true` | Run MuscleMap segmentation on the Dixon opposed-phase image |
+| `segmentfat` | Segment Fat | boolean | `false` | Run MuscleMap segmentation on the Dixon fat image |
 | `labeltransform` | Scale labels to lower integer range for DICOM 12BIT | boolean | `true` | Applying label transformation: 3 * (label_in // 10) + (label_in % 10) |
+| `metricsoutput` | Metrics output | choice | `all` | Select where MuscleMap average metrics are returned |
 | `bodyregion` | Body Region | choice | `wholebody, abdomen, pelvis, thigh, leg` | Select the body region for segmentation |
 | `chunksize` | Chunk Size | string | `100` | Chunk size between 5 and 200 - change for memory optimization on GPU |
 | `spatialoverlap` | Spatial Overlap | int | `50` | Spatial overlap percentage |

--- a/recipes/musclemap/params.sh
+++ b/recipes/musclemap/params.sh
@@ -2,7 +2,7 @@
 # build image here: https://github.com/NeuroDesk/neurocontainers and add mrd server instructions: https://www.neurodesk.org/docs/getting-started/neurocontainers/openrecon/
 # specify the repostiory and name of the docker image: https://hub.docker.com/orgs/vnmd/repositories
 export toolName=musclemap
-export version=1.3.34
+export version=1.3.37
 export baseDockerImage=vnmd/${toolName}_${version}
 # this image is build based on 
 # https://github.com/neurodesk/neurocontainers/blob/main/recipes/musclemap/build.yaml


### PR DESCRIPTION
## Summary

This PR updates OpenRecon metadata for **musclemap** from the latest successful neurocontainers build.

## Changes

- Update `recipes/musclemap/OpenReconLabel.json` from neurocontainers
- Set `recipes/musclemap/params.sh` version to `1.3.37`

- Copy `recipes/musclemap/OpenReconREADME.md` from neurocontainers to `recipes/musclemap/README.md` for OpenRecon PDF generation

🤖 Generated by neurocontainers CI | Created by @stebo85