### PR TITLE
Update musclemap OpenRecon metadata to 1.3.38

### DIFF
--- a/recipes/musclemap/README.md
+++ b/recipes/musclemap/README.md
@@ -49,7 +49,8 @@ the same source-native passthrough handling.
 
 MuscleMap segmentation images are sent after the source passthrough stream as
 source-geometry 2D masks with fresh series identity, fresh SOP identity,
-`SequenceDescriptionAdditional = openrecon`, `Keep_image_geometry = 1`,
+`SequenceDescriptionAdditional` set to the segmented source Dixon contrast,
+`Keep_image_geometry = 1`,
 `DataRole = Segmentation`, and `SegmentSourceGeometry = 1`. This matches the
 `openreconi2iexample` 2D + detach + after-originals path when
 `segmentpostprocessingstamp` is disabled. Optional metrics report output follows
@@ -70,6 +71,10 @@ For running this in Open Recon we need a reversible int16-safe mapping:
 `original = 10 * (mapped // 3) + (mapped % 3)`
 
 This transform is valid for labels ending in `0`, `1`, or `2`
+
+Metrics extraction uses the original unscaled labels so MuscleMap can map label
+IDs to anatomy names, even when the returned segmentation overlay is scaled for
+DICOM.
 
 | Region | Anatomy | Side | Value | Int16 Mapped |
 | :--- | :--- | :--- | ---: | ---: |

--- a/recipes/musclemap/params.sh
+++ b/recipes/musclemap/params.sh
@@ -2,7 +2,7 @@
 # build image here: https://github.com/NeuroDesk/neurocontainers and add mrd server instructions: https://www.neurodesk.org/docs/getting-started/neurocontainers/openrecon/
 # specify the repostiory and name of the docker image: https://hub.docker.com/orgs/vnmd/repositories
 export toolName=musclemap
-export version=1.3.37
+export version=1.3.38
 export baseDockerImage=vnmd/${toolName}_${version}
 # this image is build based on 
 # https://github.com/neurodesk/neurocontainers/blob/main/recipes/musclemap/build.yaml


### PR DESCRIPTION
## Summary

This PR updates OpenRecon metadata for **musclemap** from the latest successful neurocontainers build.

## Changes

- Update `recipes/musclemap/OpenReconLabel.json` from neurocontainers
- Set `recipes/musclemap/params.sh` version to `1.3.38`

- Copy `recipes/musclemap/OpenReconREADME.md` from neurocontainers to `recipes/musclemap/README.md` for OpenRecon PDF generation

🤖 Generated by neurocontainers CI | Created by @stebo85