### PR TITLE
Update vesselboost OpenRecon metadata to 2.0.62

### DIFF
--- a/recipes/vesselboost/README.md
+++ b/recipes/vesselboost/README.md
@@ -11,7 +11,9 @@ Use this reconstruction pipeline on 3D TOF-MRA image data.
 The main derived output is named `<source>_vesselboost`, where `<source>` is the
 incoming source `SeriesDescription` or, when that is absent, the incoming
 `SequenceDescription`. If neither source name is available, the fallback name is
-`vesselboost`. Returned scanner series use `OR` as the short OpenRecon suffix.
+`vesselboost`. Most returned scanner series use `OR` as the short OpenRecon suffix.
+When `vbsegmentationmips` is enabled, the source-geometry segmentation stream
+uses the `openrecon` suffix to mirror `openreconi2iexample`.
 By default, OpenRecon returns restamped original MRA images first as
 `<source>_original`, then sends one source-image-header 2D VesselBoost
 segmentation image per source image. Optional sagittal and coronal reformat
@@ -70,13 +72,14 @@ attached to the original stream.
 When `vbsegmentationmips` is enabled, VesselBoost instead mirrors the
 `openreconi2iexample` `2d_segment_header` path: the segmentation is sent as a 2D
 source-geometry segmentation-header stream with `DataRole = Segmentation`,
-`SegmentSourceGeometry = 1`, `SegmentOutputGeometry = 2d`, no
-`SegmentSourceImageHeader`, scanner post-processing child-role metadata matching
-the segmentation `image_series_index`, and no `ImageTypeValue3`. This lets
-scanner-created segmentation MIPs appear as their own post-processed segmentation
-series instead of being folded into original MIP side products. Reformatted
-sagittal and coronal outputs remain explicit packed 3D MRD volumes without
-source-image-header stamping.
+`SegmentSourceGeometry = 1`, `SegmentOutputGeometry = 2d`,
+`SequenceDescriptionAdditional = openrecon`, no `SegmentSourceImageHeader`,
+scanner post-processing child-role metadata matching the segmentation
+`image_series_index`, and no `ImageTypeValue3`. This lets scanner-created
+segmentation MIPs appear as their own post-processed segmentation series instead
+of being folded into original MIP side products. Reformatted sagittal and
+coronal outputs remain explicit packed 3D MRD volumes without source-image-header
+stamping.
 
 ## Citation
 

--- a/recipes/vesselboost/params.sh
+++ b/recipes/vesselboost/params.sh
@@ -2,7 +2,7 @@
 
 # build image here: https://github.com/NeuroDesk/neurocontainers and add mrd server instructions: https://www.neurodesk.org/docs/getting-started/neurocontainers/openrecon/
 # specify the repostiory and name of the docker image: https://hub.docker.com/orgs/vnmd/repositories
-export version=2.0.61
+export version=2.0.62
 export baseDockerImage=vnmd/vesselboost_${version}
 # this image is build based on 
 # https://github.com/neurodesk/neurocontainers/blob/main/recipes/vesselboost/build.yaml


### PR DESCRIPTION
## Summary

This PR updates OpenRecon metadata for **vesselboost** from the latest successful neurocontainers build.

## Changes

- Update `recipes/vesselboost/OpenReconLabel.json` from neurocontainers
- Set `recipes/vesselboost/params.sh` version to `2.0.62`

- Copy `recipes/vesselboost/OpenReconREADME.md` from neurocontainers to `recipes/vesselboost/README.md` for OpenRecon PDF generation

🤖 Generated by neurocontainers CI | Created by @stebo85