### PR TITLE
Update spinalcordtoolbox OpenRecon metadata to 7.1.21

### DIFF
--- a/recipes/spinalcordtoolbox/params.sh
+++ b/recipes/spinalcordtoolbox/params.sh
@@ -2,7 +2,7 @@
 # build image here: https://github.com/NeuroDesk/neurocontainers and add mrd server instructions: https://www.neurodesk.org/docs/getting-started/neurocontainers/openrecon/
 # specify the repostiory and name of the docker image: https://hub.docker.com/orgs/vnmd/repositories
 export toolName=spinalcordtoolbox
-export version=7.1.20
+export version=7.1.21
 export baseDockerImage=vnmd/${toolName}_${version}
 # this image is build based on 
 # https://github.com/neurodesk/neurocontainers/blob/main/recipes/spinalcordtoolbox/build.yaml


### PR DESCRIPTION
## Summary

This PR updates OpenRecon metadata for **spinalcordtoolbox** from the latest successful neurocontainers build.

## Changes

- Update `recipes/spinalcordtoolbox/OpenReconLabel.json` from neurocontainers
- Set `recipes/spinalcordtoolbox/params.sh` version to `7.1.21`

- Copy `recipes/spinalcordtoolbox/OpenReconREADME.md` from neurocontainers to `recipes/spinalcordtoolbox/README.md` for OpenRecon PDF generation

🤖 Generated by neurocontainers CI | Created by @stebo85