### PR TITLE
Update openmsk OpenRecon metadata to 0.1.2

### DIFF
--- a/recipes/openmsk/README.md
+++ b/recipes/openmsk/README.md
@@ -38,7 +38,6 @@ python3 builder/validation.py recipes/openmsk/build.yaml
 python -m builder generate openmsk --recreate --architecture x86_64
 ```
 
-Manual OpenRecon test procedure is in `recipes/openmsk/test.yaml`. To enable
-NSM/BScore at build time, provide a Hugging Face token in `HF_TOKEN` so the
-optional `aagatti/ShapeMedKnee` snapshot can be downloaded into
+To enable NSM/BScore at build time, provide a Hugging Face token in `HF_TOKEN`
+so the optional `aagatti/ShapeMedKnee` snapshot can be downloaded into
 `/opt/NSM_MODELS`.


### PR DESCRIPTION
## Summary

This PR updates OpenRecon metadata for **openmsk** from the latest successful neurocontainers build.

## Changes

- Update `recipes/openmsk/OpenReconLabel.json` from neurocontainers
- Set `recipes/openmsk/params.sh` version to `0.1.2`

- Copy `recipes/openmsk/OpenReconREADME.md` from neurocontainers to `recipes/openmsk/README.md` for OpenRecon PDF generation

🤖 Generated by neurocontainers CI | Created by @Vbitz