### PR TITLE
Update qsmxt OpenRecon metadata to 9.0.0

### DIFF
--- a/recipes/qsmxt/README.md
+++ b/recipes/qsmxt/README.md
@@ -25,3 +25,32 @@ fallback `echotimems` plus `echospacingms` is only for test or emergency use.
 
 Default output is the QSM map (`Chimap`). Enable `sendoutputs=all` to return all
 QSMxT derivatives that exist after the run.
+
+## UI Parameters
+
+| GUI label | Parameter id | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| config | `config` | choice | `qsmxt` | Selects the MRD server configuration. |
+| Output maps | `sendoutputs` | choice | `qsm` | Selects which QSMxT derivatives are sent back. |
+| Send original | `sendoriginal` | boolean | `false` | Sends original magnitude and phase image series before derived outputs. |
+| Max echoes | `maxechoes` | int | `0` | Limits the number of magnitude/phase echo pairs; `0` uses all pairs. |
+| Echo times | `echotimesms` | string | empty | Optional comma-separated echo times in ms. |
+| First echo | `echotimems` | double | `20.0` | Fallback first echo time in ms. |
+| Echo spacing | `echospacingms` | double | `5.0` | Fallback echo spacing in ms. |
+| Field strength | `fieldstrength` | double | `3.0` | Magnetic field strength written to QSMxT sidecars. |
+| B0 direction | `b0dir` | string | `0,0,1` | B0 direction vector written to QSMxT sidecars. |
+| QSM algorithm | `qsmalgorithm` | choice | `default` | Optional QSMxT inversion algorithm override. |
+| Unwrap | `unwrappingalgorithm` | choice | `default` | Optional QSMxT phase-unwrapping algorithm override. |
+| Background | `bfalgorithm` | choice | `default` | Optional background-field removal algorithm override. |
+| Mask preset | `maskpreset` | choice | `default` | Optional QSMxT masking preset override. |
+
+## Open Source Development
+
+The source for this OpenRecon package is in the NeuroContainers repository:
+https://github.com/NeuroDesk/neurocontainers/tree/main/recipes/qsmxt
+
+For bugs and feature requests, opening an issue in the NeuroContainers
+repository is preferred: https://github.com/NeuroDesk/neurocontainers/issues.
+Questions can also be posted in the Neurodesk discussion forum at
+https://github.com/orgs/neurodesk/discussions or sent via
+https://neurodesk.org/contact/.


### PR DESCRIPTION
## Summary

This PR updates OpenRecon metadata for **qsmxt** from the latest successful neurocontainers build.

## Changes

- Update `recipes/qsmxt/OpenReconLabel.json` from neurocontainers
- Set `recipes/qsmxt/params.sh` version to `9.0.0`

- Copy `recipes/qsmxt/OpenReconREADME.md` from neurocontainers to `recipes/qsmxt/README.md` for OpenRecon PDF generation

🤖 Generated by neurocontainers CI | Created by @astewartau