### PR TITLE
Update musclemap OpenRecon metadata to 1.3.45

### DIFF
--- a/recipes/musclemap/OpenReconLabel.json
+++ b/recipes/musclemap/OpenReconLabel.json
@@ -88,7 +88,7 @@
       "id": "composesegmentation",
       "label": { "en": "Compose segmentation" },
       "type": "boolean",
-      "information": { "en": "Enable whole-body composing by replacing the Fat-Fraction series with MuscleMap labels. Uses the genuine Fat-Fraction images as carriers so the labels inherit the real ComposingGroup routing; requires a Dixon protocol that produces Fat-Fraction. Re-threshold the Adaptive-blended labelmap offline." },
+      "information": { "en": "Enable whole-body composing by replacing the Fat-Fraction series with MuscleMap labels. The segmentation may be computed from the selected source contrast, such as Opposed Phase, but the scanner-composed output is routed through the Fat-Fraction/2ptFF compose channel and may be named like Composed_2ptFF_COMP_1. If multiple segmentation contrasts are selected, compose mode uses only the first selected contrast in this order: Water, In-Phase, Opposed Phase, Fat. Requires a Dixon protocol that produces Fat-Fraction. Re-threshold the Adaptive-blended labelmap offline." },
       "default": false
     },
     {

--- a/recipes/musclemap/params.sh
+++ b/recipes/musclemap/params.sh
@@ -2,7 +2,7 @@
 # build image here: https://github.com/NeuroDesk/neurocontainers and add mrd server instructions: https://www.neurodesk.org/docs/getting-started/neurocontainers/openrecon/
 # specify the repostiory and name of the docker image: https://hub.docker.com/orgs/vnmd/repositories
 export toolName=musclemap
-export version=1.3.44
+export version=1.3.45
 export baseDockerImage=vnmd/${toolName}_${version}
 # this image is build based on 
 # https://github.com/neurodesk/neurocontainers/blob/main/recipes/musclemap/build.yaml


### PR DESCRIPTION
## Summary

This PR updates OpenRecon metadata for **musclemap** from the latest successful neurocontainers build.

## Changes

- Update `recipes/musclemap/OpenReconLabel.json` from neurocontainers
- Set `recipes/musclemap/params.sh` version to `1.3.45`

- Copy `recipes/musclemap/OpenReconREADME.md` from neurocontainers to `recipes/musclemap/README.md` for OpenRecon PDF generation

🤖 Generated by neurocontainers CI | Created by @stebo85