### PR TITLE
Update qsmxt OpenRecon metadata to 9.0.6

### DIFF
--- a/recipes/qsmxt/OpenReconLabel.json
+++ b/recipes/qsmxt/OpenReconLabel.json
@@ -70,7 +70,7 @@
       "label": { "en": "Send original" },
       "type": "boolean",
       "information": { "en": "Send original magnitude and phase image series before derived QSMxT output." },
-      "default": true
+      "default": false
     },
     {
       "id": "qsmalgorithm",

--- a/recipes/qsmxt/README.md
+++ b/recipes/qsmxt/README.md
@@ -34,9 +34,10 @@ adapter; for example, `t2_swi_tra_wave4_2mm` does not provide the required
 unfiltered phase data and should not be used for QSMxT. Start from a plain GRE
 sequence instead, and enable both phase and magnitude reconstruction.
 
-The scanner UI defaults are set for a robust inline QSM run: originals are
-returned before the QSM map, QSM inversion uses RTS, unwrapping uses ROMEO,
-background-field removal uses PDF, and masking uses the robust-threshold preset.
+The scanner UI defaults are set for a robust inline QSM run: only the QSM map is
+returned, QSM inversion uses RTS, unwrapping uses ROMEO, background-field removal
+uses PDF, and masking uses the robust-threshold preset. Enable `sendoriginal`
+only when the original magnitude and phase series are needed for debugging.
 
 ## Input Data
 
@@ -49,7 +50,7 @@ Do not use filtered SWI phase images as QSMxT input.
 | --- | --- | --- | --- | --- |
 | config | `config` | choice | `qsmxt` | Selects the MRD server configuration. |
 | Output maps | `sendoutputs` | choice | `qsm` | Selects which QSMxT derivatives are sent back. |
-| Send original | `sendoriginal` | boolean | `true` | Sends original magnitude and phase image series before derived outputs. |
+| Send original | `sendoriginal` | boolean | `false` | Sends original magnitude and phase image series before derived outputs. |
 | QSM algorithm | `qsmalgorithm` | choice | `rts` | QSMxT inversion algorithm. |
 | Unwrap | `unwrappingalgorithm` | choice | `romeo` | QSMxT phase-unwrapping algorithm. |
 | Background | `bfalgorithm` | choice | `pdf` | QSMxT background-field removal algorithm. |


### PR DESCRIPTION
## Summary

This PR updates OpenRecon metadata for **qsmxt** from the latest successful neurocontainers build.

## Changes

- Update `recipes/qsmxt/OpenReconLabel.json` from neurocontainers
- Set `recipes/qsmxt/params.sh` version to `9.0.6`

- Copy `recipes/qsmxt/OpenReconREADME.md` from neurocontainers to `recipes/qsmxt/README.md` for OpenRecon PDF generation

🤖 Generated by neurocontainers CI | Created by @stebo85