### PR TITLE
Update openmsk OpenRecon metadata to 0.1.7

### DIFF
--- a/recipes/openmsk/OpenReconLabel.json
+++ b/recipes/openmsk/OpenReconLabel.json
@@ -93,6 +93,20 @@
       "default": false
     },
     {
+      "id": "runnsm",
+      "label": { "en": "Legacy NSM flag" },
+      "type": "boolean",
+      "information": { "en": "Accepted for older scanner protocols only; ignored because ShapeMedKnee assets are not packaged" },
+      "default": false
+    },
+    {
+      "id": "runbscore",
+      "label": { "en": "Legacy BScore flag" },
+      "type": "boolean",
+      "information": { "en": "Accepted for older scanner protocols only; ignored because ShapeMedKnee assets are not packaged" },
+      "default": false
+    },
+    {
       "id": "qdesstrms",
       "label": { "en": "qDESS TR" },
       "type": "double",

--- a/recipes/openmsk/README.md
+++ b/recipes/openmsk/README.md
@@ -33,9 +33,12 @@ scanner. Runtime logs report where every qDESS value came from.
 - `sendoriginal`: return original images before derived outputs.
 - `segmodel`: KneePipeline model name (`acl_qdess_bone_july_2024` by default;
   `goyal_sagittal`, `goyal_coronal`, `goyal_axial`, and `nnunet_knee` are
-  also packaged).
+  also packaged). The packaged `nnunet_knee` path runs nnU-Net with
+  scanner-safe single preprocessing/export worker defaults.
 - `computethickness`: run slower mesh/thickness analysis after the segmentation
   has been sent.
+- `runnsm`, `runbscore`: accepted for legacy scanner protocol compatibility
+  only; ignored because the gated ShapeMedKnee assets are not packaged.
 - `qdesstrms`, `qdesste1ms`, `qdesste2ms`, `qdessflipangledeg`,
   `qdessglarea`, `qdesstgus`: fallback TR, TE1, TE2, flip angle, GL area, and
   TG values used to synthesize the qDESS DICOM input when MRD metadata is


### PR DESCRIPTION
## Summary

This PR updates OpenRecon metadata for **openmsk** from the latest successful neurocontainers build.

## Changes

- Update `recipes/openmsk/OpenReconLabel.json` from neurocontainers
- Set `recipes/openmsk/params.sh` version to `0.1.7`

- Copy `recipes/openmsk/OpenReconREADME.md` from neurocontainers to `recipes/openmsk/README.md` for OpenRecon PDF generation

🤖 Generated by neurocontainers CI | Created by @stebo85