### PR TITLE
Add qsmxt OpenRecon recipe

### DIFF
--- a/recipes/qsmxt/OpenReconLabel.json
+++ b/recipes/qsmxt/OpenReconLabel.json
@@ -1,0 +1,135 @@
+{
+  "general": {
+    "name": { "en": "qsmxt" },
+    "version": "VERSION_WILL_BE_REPLACED_BY_SCRIPT",
+    "vendor": "neurodesk",
+    "information": { "en": "QSMxT quantitative susceptibility mapping from reconstructed magnitude and phase images." },
+    "id": "qsmxt",
+    "regulatory_information": {
+      "device_trade_name": "qsmxt",
+      "production_identifier": "VERSION_WILL_BE_REPLACED_BY_SCRIPT",
+      "manufacturer_address": "Erlangen, Germany",
+      "made_in": "DE",
+      "manufacture_date": "2026/06/26",
+      "material_number": "qsmxt_VERSION_WILL_BE_REPLACED_BY_SCRIPT",
+      "gtin": "00860000171212",
+      "udi": "(01)00860000171212(21)VERSION_WILL_BE_REPLACED_BY_SCRIPT",
+      "safety_advices": "",
+      "special_operating_instructions": "OpenRecon QSMxT reconstruction",
+      "additional_relevant_information": ""
+    }
+  },
+  "reconstruction": {
+    "transfer_protocol": {
+      "protocol": "ISMRMRD",
+      "version": "1.4.1"
+    },
+    "port": 9002,
+    "emitter": "image",
+    "injector": "image",
+    "can_process_adjustment_data": false,
+    "can_use_gpu": false,
+    "min_count_required_gpus": 0,
+    "min_required_gpu_memory": 0,
+    "min_required_memory": 16000,
+    "min_count_required_cpu_cores": 4,
+    "content_qualification_type": "RESEARCH"
+  },
+  "parameters": [
+    {
+      "id": "config",
+      "label": { "en": "config" },
+      "type": "choice",
+      "values": [
+        {
+          "id": "qsmxt",
+          "name": { "en": "qsmxt" }
+        }
+      ],
+      "default": "qsmxt",
+      "information": { "en": "Define the config to be executed by the MRD server." }
+    },
+    {
+      "id": "sendoutputs",
+      "label": { "en": "Output maps" },
+      "type": "choice",
+      "values": [
+        { "id": "qsm", "name": { "en": "QSM only" } },
+        { "id": "all", "name": { "en": "All available" } },
+        { "id": "magnitude", "name": { "en": "Magnitude" } },
+        { "id": "mask", "name": { "en": "Mask" } },
+        { "id": "swi", "name": { "en": "SWI" } },
+        { "id": "t2star", "name": { "en": "T2 star" } },
+        { "id": "r2star", "name": { "en": "R2 star" } }
+      ],
+      "default": "qsm",
+      "information": { "en": "Select which QSMxT derivatives to send back to OpenRecon." }
+    },
+    {
+      "id": "sendoriginal",
+      "label": { "en": "Send original" },
+      "type": "boolean",
+      "information": { "en": "Send original magnitude and phase image series before derived QSMxT output." },
+      "default": false
+    },
+    {
+      "id": "qsmalgorithm",
+      "label": { "en": "QSM algorithm" },
+      "type": "choice",
+      "values": [
+        { "id": "default", "name": { "en": "Default" } },
+        { "id": "rts", "name": { "en": "RTS" } },
+        { "id": "tv", "name": { "en": "TV" } },
+        { "id": "tkd", "name": { "en": "TKD" } },
+        { "id": "tsvd", "name": { "en": "TSVD" } },
+        { "id": "tgv", "name": { "en": "TGV" } },
+        { "id": "tikhonov", "name": { "en": "Tikhonov" } },
+        { "id": "nltv", "name": { "en": "NLTV" } },
+        { "id": "medi", "name": { "en": "MEDI" } },
+        { "id": "ilsqr", "name": { "en": "iLSQR" } },
+        { "id": "qsmart", "name": { "en": "QSMART" } }
+      ],
+      "default": "rts",
+      "information": { "en": "QSMxT inversion algorithm. RTS is the recommended default for robust inline QSM." }
+    },
+    {
+      "id": "unwrappingalgorithm",
+      "label": { "en": "Unwrap" },
+      "type": "choice",
+      "values": [
+        { "id": "default", "name": { "en": "Default" } },
+        { "id": "romeo", "name": { "en": "ROMEO" } },
+        { "id": "laplacian", "name": { "en": "Laplacian" } }
+      ],
+      "default": "romeo",
+      "information": { "en": "QSMxT phase unwrapping algorithm. ROMEO is the recommended default for multi-echo QSM." }
+    },
+    {
+      "id": "bfalgorithm",
+      "label": { "en": "Background" },
+      "type": "choice",
+      "values": [
+        { "id": "default", "name": { "en": "Default" } },
+        { "id": "vsharp", "name": { "en": "VSHARP" } },
+        { "id": "pdf", "name": { "en": "PDF" } },
+        { "id": "lbv", "name": { "en": "LBV" } },
+        { "id": "ismv", "name": { "en": "iSMV" } },
+        { "id": "sharp", "name": { "en": "SHARP" } }
+      ],
+      "default": "pdf",
+      "information": { "en": "QSMxT background field removal algorithm. PDF is the recommended default for inline QSM." }
+    },
+    {
+      "id": "maskpreset",
+      "label": { "en": "Mask preset" },
+      "type": "choice",
+      "values": [
+        { "id": "default", "name": { "en": "Default" } },
+        { "id": "robust-threshold", "name": { "en": "Robust threshold" } },
+        { "id": "bet", "name": { "en": "BET" } }
+      ],
+      "default": "robust-threshold",
+      "information": { "en": "QSMxT masking preset. Robust threshold avoids external BET dependencies and is the recommended inline default." }
+    }
+  ]
+}

--- a/recipes/qsmxt/README.md
+++ b/recipes/qsmxt/README.md
@@ -1,0 +1,78 @@
+# QSMxT OpenRecon
+
+This OpenRecon app runs QSMxT Quantitative Susceptibility Mapping (QSM) inline on
+the scanner. It is an image-in/image-out app: it receives reconstructed ISMRMRD
+image messages, separates the magnitude and phase series, writes a temporary BIDS
+MEGRE dataset, runs the QSMxT v9 Rust binary, and sends the selected derivatives
+back as derived MRD image series.
+
+This OpenRecon tool is based on QSMxT (https://github.com/QSMxT/QSMxT).
+
+Reference: Stewart AW, Robinson SD, O'Brien K, Jin J, Widhalm G, Hangel G, Walls A,
+Goodwin J, Eckstein K, Tourell M, Morgan C, Narayanan A, Barth M, Bollmann S.
+"QSMxT: Robust masking and artifact reduction for quantitative susceptibility
+mapping". Magnetic Resonance in Medicine 87.3 (2022): 1289-1300.
+https://doi.org/10.1002/mrm.29048
+
+## Input Data
+
+Use a plain GRE acquisition with unfiltered phase and magnitude outputs enabled.
+Enable both phase and magnitude reconstruction on the sequence.
+
+QSMxT needs unfiltered phase data. SWI sequences that already apply SWI-specific
+phase processing or filtering are **not** suitable inputs for this OpenRecon
+adapter; for example, `t2_swi_tra_wave4_2mm` does not provide the required
+unfiltered phase data and should not be used for QSMxT. Start from a plain GRE
+sequence instead.
+
+The wrapper expects one magnitude series and one phase series. It classifies phase
+data from MRD image type metadata, DICOM image type metadata, or source series
+names such as `phase`, `pha`, or `_Pha`. If explicit metadata is absent and exactly
+two series are present, the lower dynamic-range series is used as phase.
+
+Echo grouping, echo times, field strength, and B0 direction are derived from the
+incoming MRD image stream and generated NIfTI geometry.
+
+## Parameters
+
+| Parameter id | Type | Default | Description |
+| --- | --- | --- | --- |
+| `config` | choice | `qsmxt` | Selects this OpenRecon app / the MRD server configuration. |
+| `sendoutputs` | choice | `qsm` | Selects which QSMxT derivatives are sent back (QSM only, All available, Magnitude, Mask, SWI, T2\*, R2\*). |
+| `sendoriginal` | boolean | `false` | If enabled, returns the original magnitude and phase image series before the derived QSMxT output. |
+| `qsmalgorithm` | choice | `rts` | QSMxT dipole-inversion algorithm (RTS, TV, TKD, TSVD, TGV, Tikhonov, NLTV, MEDI, iLSQR, QSMART). |
+| `unwrappingalgorithm` | choice | `romeo` | QSMxT phase-unwrapping algorithm (ROMEO, Laplacian). |
+| `bfalgorithm` | choice | `pdf` | QSMxT background-field removal algorithm (PDF, VSHARP, LBV, iSMV, SHARP). |
+| `maskpreset` | choice | `robust-threshold` | QSMxT masking preset (Robust threshold, BET). |
+
+The scanner UI defaults are set for a robust inline QSM run: only the QSM map is
+returned, inversion uses RTS, unwrapping uses ROMEO, background-field removal uses
+PDF, and masking uses the robust-threshold preset (which avoids external BET
+dependencies). Enable `sendoriginal` only when the original magnitude and phase
+series are needed for debugging.
+
+## Outputs
+
+For each derived magnitude/phase echo group the wrapper writes a BIDS MEGRE pair:
+
+```text
+sub-01/anat/sub-01_acq-<source>_echo-N_part-mag_MEGRE.nii.gz
+sub-01/anat/sub-01_acq-<source>_echo-N_part-phase_MEGRE.nii.gz
+```
+
+The default output is the QSM map (`Chimap`), returned as a derived MRD image
+series. Set `sendoutputs=all` to return all QSMxT derivatives that exist after the
+run (e.g. QSM, magnitude, mask, SWI, T2\*, R2\*). When `sendoriginal` is enabled,
+the original magnitude and phase series are sent first, followed by the derived
+QSMxT output.
+
+## Open Source Development
+
+The source for this OpenRecon package is in the NeuroContainers repository:
+https://github.com/NeuroDesk/neurocontainers/tree/main/recipes/qsmxt
+
+For bugs and feature requests, opening an issue in the NeuroContainers repository
+is preferred: https://github.com/NeuroDesk/neurocontainers/issues. Questions can
+also be posted in the Neurodesk discussion forum at
+https://github.com/orgs/neurodesk/discussions or sent via
+https://neurodesk.org/contact/.

--- a/recipes/qsmxt/params.sh
+++ b/recipes/qsmxt/params.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# build image here: https://github.com/NeuroDesk/neurocontainers and add mrd server instructions: https://www.neurodesk.org/docs/getting-started/neurocontainers/openrecon/
+# specify the repostiory and name of the docker image: https://hub.docker.com/orgs/vnmd/repositories
+export toolName=qsmxt
+export version=9.0.7
+export baseDockerImage=vnmd/${toolName}_${version}
+# this image is build based on
+# https://github.com/neurodesk/neurocontainers/blob/main/recipes/qsmxt/build.yaml
+# source .venv/bin/activate
+# cd recipes/qsmxt
+# /bin/bash ../build.sh --local-cache


### PR DESCRIPTION
## Add qsmxt OpenRecon recipe

Packages **QSMxT v9** (the single self-contained Rust binary) as an OpenRecon app.

### What it does
Image-in / image-out app: it receives reconstructed **magnitude** and **phase** MRD image series, writes a temporary BIDS MEGRE dataset, runs the QSMxT v9 binary, and returns the selected derivatives (QSM map by default).

Scanner-facing defaults target a robust inline QSM run:
- Inversion: **RTS**
- Unwrapping: **ROMEO**
- Background-field removal: **PDF**
- Masking: **robust-threshold** (no external BET dependency)

Parameters exposed in the scanner UI: `config`, `sendoutputs`, `sendoriginal`, `qsmalgorithm`, `unwrappingalgorithm`, `bfalgorithm`, `maskpreset`.

### Base image
Wraps `vnmd/qsmxt_9.0.7`, built from the [NeuroContainers qsmxt recipe](https://github.com/NeuroDesk/neurocontainers/tree/main/recipes/qsmxt), which bakes in the `python-ismrmrd-server` MRD adapter, `qsmxt.py`, and `OpenReconLabel.json` under `/opt/code/python-ismrmrd-server`.

### Validation / testing
- `OpenReconLabel.json` passes `OpenReconSchema_1.1.0.json` and the metadata rules used by `validate_recipes.py` (single `config` choice param, default config id maps to the importable `qsmxt.py`).
- Built the distributable locally (`build.sh --local-cache`) → `OpenRecon_neurodesk_qsmxt_V9.0.7.zip`; `build.py`'s in-image config-module validation passed.
- Ran the full pipeline end-to-end on a real Philips 3T 6-echo GRE dataset: DICOM → MRD stream → the actual `qsmxt.py` wrapper (mag/phase split, 6-echo grouping, BIDS write) → `qsmxt run` → QSM map returned over MRD. Output values land in the expected physiological susceptibility range.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
