### PR TITLE
Update sodiumnufft OpenRecon metadata to 0.1.8

### DIFF
--- a/recipes/sodiumnufft/README.md
+++ b/recipes/sodiumnufft/README.md
@@ -68,12 +68,13 @@ reconstruction field of view in cm before the adjoint NUFFT.
 
 - The reconstruction is implemented for raw k-space input. If image data is
   sent to this app, the images are returned unchanged.
-- The derived output is magnitude-only and is emitted as one 2D image per
-  reconstructed matrix slice. Slice count and volume grouping therefore follow
-  the reconstruction matrix (normally the scanner Base Resolution), not the
-  protocol's Slices per Slab value.
+- The derived output is magnitude-only and is emitted as one explicit 3D MRD
+  image whose depth is the reconstructed matrix size. This prevents the Siemens
+  injector from grouping separate 2D messages using the source protocol's
+  Slices per Slab value and produces one 64-frame volume like the ICE recon.
 - Output pixels are flipped up-down and then left-right to match the ICE
-  reconstruction display orientation.
+  reconstruction display orientation. The read direction is reversed with the
+  left-right pixel flip so scanner R/L markers remain correct.
 - Each reconstruction logs the FIRE-visible CPU count, CPU affinity, cgroup
   limits, configured worker cap, and effective number of coil workers.
 - `maxcoils` is mainly useful for faster smoke tests and debugging.

--- a/recipes/sodiumnufft/params.sh
+++ b/recipes/sodiumnufft/params.sh
@@ -2,7 +2,7 @@
 # build image here: https://github.com/NeuroDesk/neurocontainers and add mrd server instructions: https://www.neurodesk.org/docs/getting-started/neurocontainers/openrecon/
 # specify the repostiory and name of the docker image: https://hub.docker.com/orgs/vnmd/repositories
 export toolName=sodiumnufft
-export version=0.1.7
+export version=0.1.8
 export baseDockerImage=vnmd/${toolName}_${version}
 # this image is build based on 
 # https://github.com/neurodesk/neurocontainers/blob/main/recipes/sodiumnufft/build.yaml


### PR DESCRIPTION
## Summary

This PR updates OpenRecon metadata for **sodiumnufft** from the latest successful neurocontainers build.

## Changes

- Update `recipes/sodiumnufft/OpenReconLabel.json` from neurocontainers
- Set `recipes/sodiumnufft/params.sh` version to `0.1.8`

- Copy `recipes/sodiumnufft/OpenReconREADME.md` from neurocontainers to `recipes/sodiumnufft/README.md` for OpenRecon PDF generation

🤖 Generated by neurocontainers CI | Created by @stebo85