### PR TITLE
Update meica OpenRecon metadata to 4.0.1

### DIFF
--- a/recipes/meica/README.md
+++ b/recipes/meica/README.md
@@ -5,10 +5,20 @@ them by echo and repetition, writes one four-dimensional NIfTI time series per
 echo, runs ME-ICA v4, and returns two fixed derived MRD series.
 
 ME-ICA requires at least three echoes with matching spatial dimensions and time
-points. Echo times are read from the MRD sequence header. The adapter uses
-`EchoTime`, `EchoNumber`, MRD `contrast`, `repetition`, and slice fields to
-separate the incoming time series. It reports an error if the sequence header
-does not contain echo times. ME-ICA runs with 24 CPU workers.
+points, and each echo must contain at least 21 time points. A 20-time-point
+input passes AFNI despiking but fails when ME-ICA's initial motion-correction
+step selects volume and matrix indices 0 through 20 inclusive. Longer fMRI
+runs are strongly recommended for meaningful ICA results. Echo times are read
+from the MRD sequence header. The adapter uses `EchoTime`, `EchoNumber`, MRD
+`contrast`, `repetition`, and slice fields to separate the incoming time
+series. It reports an error if the sequence header does not contain echo times.
+ME-ICA runs with 24 CPU workers.
+
+If AFNI cannot skull-strip the optimally combined functional reference, the
+adapter treats every nonzero voxel as phantom foreground, closes one-voxel
+gaps, and fills enclosed holes so that the complete phantom interior is
+segmented. Completely empty inputs still fail instead of producing an empty
+mask.
 
 OpenRecon always returns two derived series. The `dr2s_epi` series is the
 denoised BOLD-like time series expressed as apparent `dR2*` in `s^-1`. The


### PR DESCRIPTION
## Summary

This PR updates OpenRecon metadata for **meica** from the latest successful neurocontainers build.

## Changes

- Update `recipes/meica/OpenReconLabel.json` from neurocontainers
- Set `recipes/meica/params.sh` version to `4.0.1`

- Copy `recipes/meica/OpenReconREADME.md` from neurocontainers to `recipes/meica/README.md` for OpenRecon PDF generation

🤖 Generated by neurocontainers CI | Created by @stebo85

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded ME-ICA OpenRecon adapter requirements, including echo count, matching dimensions, echo times, and minimum time points.
  * Documented failure behavior for runs with insufficient time points.
  * Clarified skull-stripping behavior, including foreground detection, gap closing, hole filling, and handling of empty inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->