### PR TITLE
Update meica OpenRecon metadata to 4.0.1

### DIFF
--- a/recipes/meica/OpenReconLabel.json
+++ b/recipes/meica/OpenReconLabel.json
@@ -45,6 +45,13 @@
       ],
       "default": "meica",
       "information": { "en": "Run the ME-ICA OpenRecon image adapter." }
+    },
+    {
+      "id": "sendoriginal",
+      "label": { "en": "Send original images" },
+      "type": "boolean",
+      "default": true,
+      "information": { "en": "Return the incoming reconstructed echo images before the derived ME-ICA series." }
     }
   ]
 }

--- a/recipes/meica/README.md
+++ b/recipes/meica/README.md
@@ -22,8 +22,10 @@ mask.
 
 OpenRecon always returns two derived series. The `dr2s_epi` series is the
 denoised BOLD-like time series expressed as apparent `dR2*` in `s^-1`. The
-`t2s_epi` series is the T2* map. These outputs are fixed and are not selectable
-in the scanner GUI.
+`t2s_epi` series is the T2* map. These derived outputs are fixed and are not
+selectable in the scanner GUI. By default, the adapter also returns the
+incoming reconstructed echo images before the two derived series. Disable
+`sendoriginal` to return only the ME-ICA outputs.
 
 The input must be reconstructed magnitude multi-echo EPI. Phase images and raw
 k-space acquisitions are not ME-ICA inputs. An anatomical image is optional in
@@ -34,6 +36,7 @@ ME-ICA and is intentionally not required by this inline adapter.
 | GUI label | Parameter id | Default | Description |
 | --- | --- | --- | --- |
 | config | `config` | `meica` | Selects the ME-ICA server module. |
+| Send original images | `sendoriginal` | `true` | Return the incoming echo images before the derived ME-ICA outputs. |
 
 ME-ICA is a research tool and is not intended for standard clinical use.
 


### PR DESCRIPTION
## Summary

This PR updates OpenRecon metadata for **meica** from the latest successful neurocontainers build.

## Changes

- Update `recipes/meica/OpenReconLabel.json` from neurocontainers
- Set `recipes/meica/params.sh` version to `4.0.1`

- Copy `recipes/meica/OpenReconREADME.md` from neurocontainers to `recipes/meica/README.md` for OpenRecon PDF generation

🤖 Generated by neurocontainers CI | Created by @stebo85

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable option to return the original reconstructed echo images alongside ME-ICA outputs.
  * The option is enabled by default and can be disabled to return only ME-ICA-derived series.

* **Documentation**
  * Clarified which ME-ICA outputs are fixed and not selectable through the scanner interface.
  * Documented the new “Send original images” setting and its default behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->