### PR TITLE
Update meica OpenRecon metadata to 4.0.1

### DIFF
--- a/recipes/meica/OpenReconLabel.json
+++ b/recipes/meica/OpenReconLabel.json
@@ -52,6 +52,13 @@
       "type": "boolean",
       "default": true,
       "information": { "en": "Return the incoming reconstructed echo images before the derived ME-ICA series." }
+    },
+    {
+      "id": "sendfloat32",
+      "label": { "en": "Send results as float32" },
+      "type": "boolean",
+      "default": false,
+      "information": { "en": "Send the derived dR2* and T2* values as unscaled float32 pixels instead of scanner-display uint16 pixels." }
     }
   ]
 }

--- a/recipes/meica/README.md
+++ b/recipes/meica/README.md
@@ -27,6 +27,11 @@ selectable in the scanner GUI. By default, the adapter also returns the
 incoming reconstructed echo images before the two derived series. Disable
 `sendoriginal` to return only the ME-ICA outputs.
 
+Derived results use scanner-display `uint16` pixels by default. Enable
+`sendfloat32` to return the resampled dR2* and T2* values as unscaled `float32`
+pixels. In float mode the robust display range is carried as window metadata;
+the pixel values themselves are not percentile-scaled or clipped.
+
 The input must be reconstructed magnitude multi-echo EPI. Phase images and raw
 k-space acquisitions are not ME-ICA inputs. An anatomical image is optional in
 ME-ICA and is intentionally not required by this inline adapter.
@@ -37,6 +42,7 @@ ME-ICA and is intentionally not required by this inline adapter.
 | --- | --- | --- | --- |
 | config | `config` | `meica` | Selects the ME-ICA server module. |
 | Send original images | `sendoriginal` | `true` | Return the incoming echo images before the derived ME-ICA outputs. |
+| Send results as float32 | `sendfloat32` | `false` | Return unscaled float32 dR2* and T2* pixels instead of display-scaled uint16 pixels. |
 
 ME-ICA is a research tool and is not intended for standard clinical use.
 


### PR DESCRIPTION
## Summary

This PR updates OpenRecon metadata for **meica** from the latest successful neurocontainers build.

## Changes

- Update `recipes/meica/OpenReconLabel.json` from neurocontainers
- Set `recipes/meica/params.sh` version to `4.0.1`

- Copy `recipes/meica/OpenReconREADME.md` from neurocontainers to `recipes/meica/README.md` for OpenRecon PDF generation

🤖 Generated by neurocontainers CI | Created by @stebo85

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to return derived dR2* and T2* results as unscaled `float32` pixel data.
  * The option is disabled by default; when enabled, display range information is provided as metadata.

* **Documentation**
  * Documented pixel representations and the new output setting for derived MRD series.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->