### PR TITLE
Update sodiumgridding OpenRecon metadata to 0.1.2

### DIFF
--- a/recipes/sodiumgridding/README.md
+++ b/recipes/sodiumgridding/README.md
@@ -71,8 +71,10 @@ width is fixed at `3.0`, matching the supplied implementation.
 
 - The derived output is magnitude-only and is emitted as one explicit 3D MRD
   image in `[z, y, x]` order.
-- Output pixels and both in-plane direction vectors are flipped to retain the
-  established ICE display orientation and scanner markers.
+- The gridding result is already in `[z, y, x]` order. Output packing preserves
+  that axis order and flips the phase/up-down and read/left-right pixel axes,
+  matching the validated offline DICOM correction. Direction metadata retains
+  the scanner-validated `A` and `R` markers.
 - Each run logs the FIRE-visible CPU count, affinity, cgroup limits, configured
   worker cap, effective virtual-coil workers, and whether pyFFTW is available.
 - Debug arrays are written below `/tmp/share/debug` with the

--- a/recipes/sodiumgridding/params.sh
+++ b/recipes/sodiumgridding/params.sh
@@ -2,7 +2,7 @@
 # build image here: https://github.com/NeuroDesk/neurocontainers and add mrd server instructions: https://www.neurodesk.org/docs/getting-started/neurocontainers/openrecon/
 # specify the repostiory and name of the docker image: https://hub.docker.com/orgs/vnmd/repositories
 export toolName=sodiumgridding
-export version=0.1.1
+export version=0.1.2
 export baseDockerImage=vnmd/${toolName}_${version}
 # this image is build based on 
 # https://github.com/neurodesk/neurocontainers/blob/main/recipes/sodiumgridding/build.yaml


### PR DESCRIPTION
## Summary

This PR updates OpenRecon metadata for **sodiumgridding** from the latest successful neurocontainers build.

## Changes

- Update `recipes/sodiumgridding/OpenReconLabel.json` from neurocontainers
- Set `recipes/sodiumgridding/params.sh` version to `0.1.2`

- Copy `recipes/sodiumgridding/OpenReconREADME.md` from neurocontainers to `recipes/sodiumgridding/README.md` for OpenRecon PDF generation

🤖 Generated by neurocontainers CI | Created by @stebo85

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified output axis ordering, pixel-axis flipping, and direction metadata in the sodium gridding runtime notes.

* **Chores**
  * Updated the sodium gridding recipe version from 0.1.1 to 0.1.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->