### PR TITLE
Update sodiumgridding_ptpi OpenRecon metadata to 0.1.0

### DIFF
--- a/recipes/sodiumgridding_ptpi/OpenReconLabel.json
+++ b/recipes/sodiumgridding_ptpi/OpenReconLabel.json
@@ -94,24 +94,6 @@
       "information": { "en": "Number of iterative Kaiser-Bessel density compensation updates. Use 0 for uniform weights." }
     },
     {
-      "id": "maxcoils",
-      "label": { "en": "Max coils" },
-      "type": "int",
-      "minimum": 0,
-      "maximum": 128,
-      "default": 0,
-      "information": { "en": "Limit physical coils before compression. Use 0 for all coils." }
-    },
-    {
-      "id": "maxworkers",
-      "label": { "en": "Max workers" },
-      "type": "int",
-      "minimum": 1,
-      "maximum": 64,
-      "default": 8,
-      "information": { "en": "Maximum number of parallel coil reconstructions." }
-    },
-    {
       "id": "coilcompression",
       "label": { "en": "Coil compression" },
       "type": "boolean",
@@ -197,17 +179,18 @@
         { "id": "zxy_fx", "name": { "en": "zxy, reverse columns" } },
         { "id": "zxy_fy", "name": { "en": "zxy, reverse rows" } },
         { "id": "zxy_fxy", "name": { "en": "zxy, reverse rows and columns" } },
+        { "id": "zyx_fz", "name": { "en": "zyx, reverse slices" } },
+        { "id": "zyx_fx_fz", "name": { "en": "zyx, reverse columns and slices" } },
+        { "id": "zyx_fy_fz", "name": { "en": "zyx, reverse rows and slices" } },
+        { "id": "zyx_fxy_fz", "name": { "en": "zyx, reverse rows, columns and slices" } },
+        { "id": "zxy_fz", "name": { "en": "zxy, reverse slices" } },
+        { "id": "zxy_fx_fz", "name": { "en": "zxy, reverse columns and slices" } },
+        { "id": "zxy_fy_fz", "name": { "en": "zxy, reverse rows and slices" } },
+        { "id": "zxy_fxy_fz", "name": { "en": "zxy, reverse rows, columns and slices" } },
         { "id": "debug", "name": { "en": "Debug sweep (all orientations)" } }
       ],
       "default": "zyx",
-      "information": { "en": "Map trajectory components into acquisition read/phase axes. Debug emits every mapping with slice kept/reversed." }
-    },
-    {
-      "id": "orientationflipslice",
-      "label": { "en": "Reverse slice axis" },
-      "type": "boolean",
-      "default": false,
-      "information": { "en": "Reverse trajectory component 2 before display-frame canonicalization." }
+      "information": { "en": "Map trajectory components into acquisition read/phase axes. The _fz variants also reverse the slice axis. Debug emits every mapping with slice kept/reversed." }
     }
   ]
 }

--- a/recipes/sodiumgridding_ptpi/README.md
+++ b/recipes/sodiumgridding_ptpi/README.md
@@ -59,8 +59,6 @@ for both echoes and infers sample timing from `sampling_time_us`.
 | Matrix size | `matrixsize` | int | `128` | Final isotropic reconstruction matrix. |
 | FOV cm | `fovcm` | string | `22.0` | Reconstruction field of view in centimetres. |
 | DCF iterations | `dcfiterations` | int | `5` | Kaiser-Bessel density compensation iterations. |
-| Max coils | `maxcoils` | int | `0` | Limit physical coils before compression; `0` uses all. |
-| Max workers | `maxworkers` | int | `8` | Parallel coil reconstruction workers. |
 | Coil compression | `coilcompression` | boolean | `true` | Use PCA variance-retention coil compression. |
 | Coil variance | `coilvarianceretention` | string | `0.9` | Variance retained by the compression basis. |
 | Coil combination | `coilcombinemode` | choice | `AC` | Adaptive combine or sum-of-squares. |
@@ -69,8 +67,20 @@ for both echoes and infers sample timing from `sampling_time_us`.
 | Phase correction | `runphasecorrection` | boolean | `true` | Run low-rank phase correction for both echoes. |
 | Low-rank rank | `phaselowrankrank` | int | `10` | Rank used for the low-rank phase table. |
 | N4 correction | `applyn4biascorrection` | boolean | `true` | Apply N4 bias correction to the final echoes. |
-| Orientation | `orientation` | choice | `zyx` | Shared sodiumgridding trajectory/display mapping. |
-| Reverse slice axis | `orientationflipslice` | boolean | `false` | Reverse trajectory component 2 before display canonicalization. |
+| Orientation | `orientation` | choice | `zyx` | Shared sodiumgridding trajectory/display mapping; `_fz` variants also reverse the slice axis. |
+
+The OpenRecon packaging schema allows at most 14 label parameters, so three
+settings are not exposed as parameters of their own:
+
+| Setting | Where it lives | Default |
+| --- | --- | --- |
+| Reverse slice axis | `_fz` suffix on the `orientation` choice | off |
+| Max coils | `SODIUMGRIDDING_PTPI_MAX_COILS` container env var | `0` (all coils) |
+| Max workers | `SODIUMGRIDDING_PTPI_MAX_WORKERS` container env var | `8` |
+
+All three are still read from `maxcoils`, `maxworkers`, and
+`orientationflipslice` when supplied in a manual JSON config, so the MRD
+contract is unchanged.
 
 ## Runtime Notes
 
@@ -82,8 +92,8 @@ for both echoes and infers sample timing from `sampling_time_us`.
   the supplied standalone script.
 - Geometry handling is delegated to `sodiumgridding.py`, so orientation changes
   should be validated the same way: use `orientation=debug` on an asymmetric
-  object or a known-side marker, then set `orientation` and
-  `orientationflipslice` to the matching result.
+  object or a known-side marker, then set `orientation` to the matching result,
+  adding the `_fz` suffix if the matching series had its slices reversed.
 
 ## Build
 


### PR DESCRIPTION
## Summary

This PR updates OpenRecon metadata for **sodiumgridding_ptpi** from the latest successful neurocontainers build.

## Changes

- Update `recipes/sodiumgridding_ptpi/OpenReconLabel.json` from neurocontainers
- Set `recipes/sodiumgridding_ptpi/params.sh` version to `0.1.0`

- Copy `recipes/sodiumgridding_ptpi/OpenReconREADME.md` from neurocontainers to `recipes/sodiumgridding_ptpi/README.md` for OpenRecon PDF generation

🤖 Generated by neurocontainers CI | Created by @stebo85